### PR TITLE
Representation tracks model

### DIFF
--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/DisplayEditor.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/DisplayEditor.java
@@ -289,6 +289,7 @@ public class DisplayEditor
         widget_naming.clear();
         selection.clear();
         group_handler.setModel(model);
+        selection_tracker.setModel(model);
 
         final DisplayModel old_model = this.model;
         if (old_model != null)

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
@@ -22,6 +22,7 @@ import org.csstudio.display.builder.editor.undo.UpdateWidgetLocationAction;
 import org.csstudio.display.builder.editor.util.GeometryTools;
 import org.csstudio.display.builder.editor.util.ParentHandler;
 import org.csstudio.display.builder.model.ChildrenProperty;
+import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.MacroizedWidgetProperty;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetProperty;
@@ -92,7 +93,7 @@ public class SelectedWidgetUITracker extends Tracker
         this.group_handler = group_handler;
         this.undo = undo;
         this.snap_constraint = new TrackerSnapConstraint(this, toolkit);
-        this.grid_constraint = new TrackerGridConstraint(toolkit);
+        this.grid_constraint = new TrackerGridConstraint();
 
         setVisible(false);
 
@@ -140,6 +141,11 @@ public class SelectedWidgetUITracker extends Tracker
 
         // When tracker moved, update widgets
         setListener(this::updateWidgetsFromTracker);
+    }
+
+    public void setModel(final DisplayModel model)
+    {
+        grid_constraint.configure(model);
     }
 
     /** Apply enabled constraints to requested position
@@ -425,12 +431,10 @@ public class SelectedWidgetUITracker extends Tracker
     }
 
     @Override
-    protected void endMouseDrag ( final MouseEvent event ) {
-
+    protected void endMouseDrag (final MouseEvent event)
+    {   // Hide snap lines when drag ends
         super.endMouseDrag(event);
-
         snap_constraint.setVisible(false);
-
     }
 
     private void bindToWidgets()

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
@@ -92,7 +92,7 @@ public class SelectedWidgetUITracker extends Tracker
         this.toolkit = toolkit;
         this.group_handler = group_handler;
         this.undo = undo;
-        this.snap_constraint = new TrackerSnapConstraint(this, toolkit);
+        this.snap_constraint = new TrackerSnapConstraint(this);
         this.grid_constraint = new TrackerGridConstraint();
 
         setVisible(false);

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/TrackerGridConstraint.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/TrackerGridConstraint.java
@@ -8,34 +8,32 @@
 package org.csstudio.display.builder.editor.tracker;
 
 
-import org.csstudio.display.builder.representation.ToolkitRepresentation;
+import org.csstudio.display.builder.model.DisplayModel;
 
 import javafx.geometry.Point2D;
-import javafx.scene.Node;
-import javafx.scene.Parent;
 
 
-/**
- * Constraint on the movement of the Tracker that snaps to a gird
- *
- * @author Kay Kasemir
+/** Constraint on the movement of the Tracker that snaps to a gird
+ *  @author Kay Kasemir
  */
-public class TrackerGridConstraint extends TrackerConstraint {
+public class TrackerGridConstraint extends TrackerConstraint
+{
+    private volatile DisplayModel model = null;
 
-    private final ToolkitRepresentation<Parent, Node> toolkit;
-
-    /** @param size Size of grid squares */
-    public TrackerGridConstraint ( final ToolkitRepresentation<Parent, Node> toolkit ) {
-        this.toolkit = toolkit;
+    public void configure(final DisplayModel model)
+    {
+        this.model = model;
     }
 
     @Override
-    public Point2D constrain ( final double x, final double y ) {
-
-         int grid_x = toolkit.getGridStepX();
-         int grid_y = toolkit.getGridStepY();
-
-        return new Point2D(Math.floor(( x + grid_x / 2 ) / grid_x) * grid_x, Math.floor(( y + grid_y / 2 ) / grid_y) * grid_y);
-
+    public Point2D constrain (final double x, final double y)
+    {
+        final DisplayModel copy = model;
+        if (copy == null)
+            return new Point2D(x, y);
+        final int grid_x = copy.propGridStepX().getValue(),
+                  grid_y = copy.propGridStepY().getValue();
+        return new Point2D(Math.floor(( x + grid_x / 2 ) / grid_x) * grid_x,
+                           Math.floor(( y + grid_y / 2 ) / grid_y) * grid_y);
     }
 }

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/TrackerSnapConstraint.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/TrackerSnapConstraint.java
@@ -16,12 +16,10 @@ import org.csstudio.display.builder.editor.util.GeometryTools;
 import org.csstudio.display.builder.model.ChildrenProperty;
 import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.Widget;
-import org.csstudio.display.builder.representation.ToolkitRepresentation;
 
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Group;
-import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.shape.Line;
 
@@ -55,8 +53,8 @@ public class TrackerSnapConstraint extends TrackerConstraint
     private DisplayModel model = null;
     private List<Widget>selected_widgets = Collections.emptyList();
 
-    private final ToolkitRepresentation<Parent, Node> toolkit;
     private final Line horiz_guide, vert_guide;
+
 
 
     /** Horizontal and/or vertical position to which we 'snapped' */
@@ -203,40 +201,33 @@ public class TrackerSnapConstraint extends TrackerConstraint
         }
     }
 
-    public TrackerSnapConstraint ( final Group group, final ToolkitRepresentation<Parent, Node> toolkit ) {
-
-        this.toolkit = toolkit;
-        this.horiz_guide = new Line();
-
+    /** @param group Group where snap lines are added */
+    public TrackerSnapConstraint(final Group group)
+    {
+        horiz_guide = new Line();
         horiz_guide.getStyleClass().add("guide_line");
         horiz_guide.setVisible(false);
 
-        this.vert_guide = new Line();
-
+        vert_guide = new Line();
         vert_guide.getStyleClass().add("guide_line");
         vert_guide.setVisible(false);
 
         group.getChildren().addAll(horiz_guide, vert_guide);
-
     }
 
     @Override
-    public void setEnabled ( final boolean enabled ) {
-
+    public void setEnabled (final boolean enabled)
+    {
         super.setEnabled(enabled);
-
-        if ( !enabled ) {
+        if (!enabled)
             setVisible(false);
-        }
-
     }
 
-    /**
-     * Sets the guidelines visible or not.
-     *
-     * @param visible {@code true} if guidelines must be visible, {@code false} otherwise.
+    /** Sets the guidelines visible or not.
+     *  @param visible {@code true} if guidelines must be visible, {@code false} otherwise.
      */
-    public void setVisible ( boolean visible ) {
+    public void setVisible(final boolean visible)
+    {
         horiz_guide.setVisible(visible);
         vert_guide.setVisible(visible);
     }
@@ -251,7 +242,6 @@ public class TrackerSnapConstraint extends TrackerConstraint
         this.selected_widgets = selected_widgets;
     }
 
-
     @Override
     public Point2D constrain(double x, double y)
     {
@@ -259,6 +249,17 @@ public class TrackerSnapConstraint extends TrackerConstraint
         final SnapSearch task = new SnapSearch(Arrays.asList(model), x, y);
         final SnapResult result = task.compute();
         // System.out.println("Done");
+
+        // Editor's viewport that's used to determine size of snap lines
+        final Parent viewport;
+        try
+        {
+            viewport = horiz_guide.getParent().getParent().getParent();
+        }
+        catch (Throwable ex)
+        {
+            throw new IllegalStateException("Expecting editor's Pane to obtain size of current viewport", ex);
+        }
 
         if (result.horiz == SnapResult.INVALID)
             horiz_guide.setVisible(false);
@@ -268,8 +269,12 @@ public class TrackerSnapConstraint extends TrackerConstraint
             horiz_guide.setStartX(x);
             horiz_guide.setStartY(0);
             horiz_guide.setEndX(x);
-            //  '-2' is necessary because the display model's bounds width is greater than 1.
-            horiz_guide.setEndY(toolkit.getDisplayHeight() - 2);
+
+            //  '-3':
+            // Snap lines will become part of the viewport.
+            // If they touch end edge of the viewport, the viewport will grow to include the snap lines.
+            // resulting in a growing viewport as the mouse is moved and the snaplines are updated.
+            horiz_guide.setEndY(viewport.getBoundsInLocal().getHeight() - 3);
             horiz_guide.setVisible(true);
         }
         if (result.vert == SnapResult.INVALID)
@@ -279,13 +284,12 @@ public class TrackerSnapConstraint extends TrackerConstraint
             y = result.vert;
             vert_guide.setStartX(0);
             vert_guide.setStartY(y);
-            //  '-2' is necessary because the display model's bounds width is greater than 1.
-            vert_guide.setEndX(toolkit.getDisplayWidth() - 2);
+            //  '-3': See above
+            vert_guide.setEndX(viewport.getBoundsInLocal().getWidth() - 3);
             vert_guide.setEndY(y);
             vert_guide.setVisible(true);
         }
 
         return new Point2D(x, y);
     }
-
 }

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/DisplayModel.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/DisplayModel.java
@@ -7,6 +7,9 @@
  *******************************************************************************/
 package org.csstudio.display.builder.model;
 
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newBooleanPropertyDescriptor;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newColorPropertyDescriptor;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newIntegerPropertyDescriptor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBackgroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMacros;
 
@@ -15,8 +18,6 @@ import java.util.List;
 import org.csstudio.display.builder.model.macros.Macros;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
-import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
-import org.csstudio.display.builder.model.properties.IntegerWidgetProperty;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.widgets.EmbeddedDisplayWidget;
 
@@ -61,44 +62,20 @@ public class DisplayModel extends Widget
     private final Macros preference_macros = Preferences.getMacros();
 
     /** 'grid_visible' property */
-    public static final WidgetPropertyDescriptor<Boolean> propGridVisible = CommonWidgetProperties.newBooleanPropertyDescriptor(WidgetPropertyCategory.MISC, "grid_visible", Messages.WidgetProperties_GridVisible);
+    public static final WidgetPropertyDescriptor<Boolean> propGridVisible = newBooleanPropertyDescriptor(WidgetPropertyCategory.MISC, "grid_visible", Messages.WidgetProperties_GridVisible);
 
     /** 'grid_color' property */
-    public static final WidgetPropertyDescriptor<WidgetColor> propGridColor = CommonWidgetProperties.newColorPropertyDescriptor(WidgetPropertyCategory.MISC, "grid_color", Messages.WidgetProperties_GridColor);
+    public static final WidgetPropertyDescriptor<WidgetColor> propGridColor = newColorPropertyDescriptor(WidgetPropertyCategory.MISC, "grid_color", Messages.WidgetProperties_GridColor);
 
     /** 'grid_step_x' property */
-    public static final WidgetPropertyDescriptor<Integer> propGridStepX = new WidgetPropertyDescriptor<Integer>(WidgetPropertyCategory.MISC, "grid_step_x", Messages.WidgetProperties_GridStepX) {
-        @Override
-        public WidgetProperty<Integer> createProperty ( final Widget widget, final Integer value ) {
-            return new IntegerWidgetProperty(this, widget, value) {
-                @Override
-                protected Integer restrictValue ( final Integer requested_value ) {
-                    if ( requested_value < 4 ) {
-                        return 4;
-                    } else {
-                        return requested_value;
-                    }
-                }
-            };
-        }
-    };
+    public static final WidgetPropertyDescriptor<Integer> propGridStepX =
+        newIntegerPropertyDescriptor(WidgetPropertyCategory.MISC, "grid_step_x", Messages.WidgetProperties_GridStepX,
+                                     4, Integer.MAX_VALUE);
 
     /** 'grid_step_y' property */
-    public static final WidgetPropertyDescriptor<Integer> propGridStepY = new WidgetPropertyDescriptor<Integer>(WidgetPropertyCategory.MISC, "grid_step_y", Messages.WidgetProperties_GridStepY) {
-        @Override
-        public WidgetProperty<Integer> createProperty ( final Widget widget, final Integer value ) {
-            return new IntegerWidgetProperty(this, widget, value) {
-                @Override
-                protected Integer restrictValue ( final Integer requested_value ) {
-                    if ( requested_value < 4 ) {
-                        return 4;
-                    } else {
-                        return requested_value;
-                    }
-                }
-            };
-        }
-    };
+    public static final WidgetPropertyDescriptor<Integer> propGridStepY =
+        newIntegerPropertyDescriptor(WidgetPropertyCategory.MISC, "grid_step_y", Messages.WidgetProperties_GridStepY,
+                                     4, Integer.MAX_VALUE);
 
     private volatile WidgetProperty<Macros> macros;
     private volatile WidgetProperty<WidgetColor> background;
@@ -120,7 +97,7 @@ public class DisplayModel extends Widget
         super.defineProperties(properties);
         properties.add(macros = propMacros.createProperty(this, new Macros()));
         properties.add(background = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
-        properties.add(gridVisible = propGridVisible.createProperty(this, false));
+        properties.add(gridVisible = propGridVisible.createProperty(this, true));
         properties.add(gridColor = propGridColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.GRID)));
         properties.add(gridStepX = propGridStepX.createProperty(this, 10));
         properties.add(gridStepY = propGridStepY.createProperty(this, 10));
@@ -180,28 +157,32 @@ public class DisplayModel extends Widget
     }
 
     /** @return 'background_color' property */
-    public WidgetProperty<WidgetColor> propBackgroundColor ( ) {
+    public WidgetProperty<WidgetColor> propBackgroundColor()
+    {
         return background;
     }
 
     /** @return 'grid_color' property */
-    public WidgetProperty<WidgetColor> propGridColor ( ) {
+    public WidgetProperty<WidgetColor> propGridColor()
+    {
         return gridColor;
     }
 
     /** @return 'grid_step_x' property */
-    public WidgetProperty<Integer> propGridStepX ( ) {
+    public WidgetProperty<Integer> propGridStepX()
+    {
         return gridStepX;
     }
 
     /** @return 'grid_step_y' property */
-    public WidgetProperty<Integer> propGridStepY ( ) {
+    public WidgetProperty<Integer> propGridStepY()
+    {
         return gridStepY;
     }
 
     /** @return 'grid_visible' property */
-    public WidgetProperty<Boolean> propGridVisible ( ) {
+    public WidgetProperty<Boolean> propGridVisible()
+    {
         return gridVisible;
     }
-
 }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -171,7 +171,6 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     /** Width of the grid lines. */
     private static final float GRID_LINE_WIDTH = 0.222F;
 
-    private Color backgroundColor = Color.WHITE;
     private Line horiz_bound, vert_bound;
 
     /** Constructor
@@ -335,28 +334,6 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     public ToolkitRepresentation<Parent, Node> openNewWindow(final DisplayModel model, Consumer<DisplayModel> close_handler) throws Exception
     {   // Use JFXStageRepresentation or RCP-based implementation
         throw new IllegalStateException("Not implemented");
-    }
-
-    @Override
-    public void setBackground ( final WidgetColor color ) {
-
-        if ( isEditMode() ) {
-            try {
-                model_root.setStyle("-fx-background: linear-gradient(from 0px 0px to 10px 10px, reflect, #D2A2A2 48%, #D2A2A2 2%, #D2D2A2 48% #D2D2A2 2%)");
-            } catch ( Exception ex ) {
-            }
-        } else {
-            model_root.setStyle("-fx-background: " + JFXUtil.webRGB(color));
-        }
-
-        if ( color != null ) {
-
-            backgroundColor = new Color(color.getRed(), color.getGreen(), color.getBlue());
-
-            updateBackground();
-
-        }
-
     }
 
     @Override
@@ -609,6 +586,16 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     @Override
     protected void updateBackground()
     {
+        final WidgetColor background = model.propBackgroundColor().getValue();
+        if (isEditMode())
+            model_root.setStyle("-fx-background: linear-gradient(from 0px 0px to 10px 10px, reflect, #D2A2A2 48%, #D2A2A2 2%, #D2D2A2 48% #D2D2A2 2%)");
+        else
+        {
+            model_root.setStyle("-fx-background: " + JFXUtil.webRGB(background));
+        }
+
+        final Color backgroundColor = new Color(background.getRed(), background.getGreen(), background.getBlue());
+
         final boolean gridVisible = isEditMode() ? model.propGridVisible().getValue() : false;
         final int gridStepX = model.propGridStepX().getValue(),
                   gridStepY = model.propGridStepY().getValue();

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -822,17 +822,4 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         }
         return CompletableFuture.completedFuture(false);
     }
-
-
-    @Override
-    public Integer getGridStepX ( ) {
-        return gridStepX;
-    }
-
-
-    @Override
-    public Integer getGridStepY ( ) {
-        return gridStepX;
-    }
-
 }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -337,14 +337,6 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     }
 
     @Override
-    public Integer getDisplayHeight ( ) {
-        /*
-         * NOTE: the current height is returned, so snap guidelines are displayed correctly.
-         */
-        return (int) ((Pane) model_root.getContent()).getHeight();
-    }
-
-    @Override
     public void setDisplayHeight ( Integer height ) {
 
         if ( height != null ) {
@@ -365,14 +357,6 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
 
         }
 
-    }
-
-    @Override
-    public Integer getDisplayWidth ( ) {
-        /*
-         * NOTE: the current width is returned, so snap guidelines are displayed correctly.
-         */
-        return (int) ((Pane) model_root.getContent()).getWidth();
     }
 
     @Override
@@ -590,9 +574,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         if (isEditMode())
             model_root.setStyle("-fx-background: linear-gradient(from 0px 0px to 10px 10px, reflect, #D2A2A2 48%, #D2A2A2 2%, #D2D2A2 48% #D2D2A2 2%)");
         else
-        {
             model_root.setStyle("-fx-background: " + JFXUtil.webRGB(background));
-        }
 
         final Color backgroundColor = new Color(background.getRed(), background.getGreen(), background.getBlue());
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -244,6 +244,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         return () -> (WidgetRepresentation<Parent, Node, Widget>) config.createExecutableExtension("class");
     }
 
+    private volatile Pane scroll_body;
     private volatile ScrollPane model_root;
     private volatile Group model_parent;
 
@@ -261,9 +262,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         model_parent = new Group();
         vert_bound = new Line();
         horiz_bound = new Line();
-
-        final Pane scroll_body = new Pane(model_parent, vert_bound, horiz_bound);
-
+        scroll_body = new Pane(model_parent, vert_bound, horiz_bound);
         model_root = new ScrollPane(scroll_body);
 
         return model_root;
@@ -337,49 +336,22 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     }
 
     @Override
-    public void setDisplayHeight ( Integer height ) {
+    public void updateDisplaySize()
+    {
+        final int width = model.propWidth().getValue();
+        final int height = model.propHeight().getValue();
+        scroll_body.setMinWidth(width);
+        scroll_body.setMinHeight(height);
 
-        if ( height != null ) {
-
-            final double h = height.doubleValue();
-
-            Platform.runLater(() -> {
-
-                ((Pane) model_root.getContent()).setMinHeight(h);
-
-                if ( isEditMode() ) {
-                    horiz_bound.setStartY(h - 1);
-                    horiz_bound.setEndY(h - 1);
-                    vert_bound.setEndY(h - 1);
-                }
-
-            });
-
+        if (isEditMode())
+        {
+            horiz_bound.setStartY(height - 1);
+            horiz_bound.setEndX(width - 1);
+            horiz_bound.setEndY(height - 1);
+            vert_bound.setStartX(width - 1);
+            vert_bound.setEndY(height - 1);
+            vert_bound.setEndX(width - 1);
         }
-
-    }
-
-    @Override
-    public void setDisplayWidth ( Integer width ) {
-
-        if ( width != null ) {
-
-            final double w = width.doubleValue();
-
-            Platform.runLater(() -> {
-
-                ((Pane) model_root.getContent()).setMinWidth(w);
-
-                if ( isEditMode() ) {
-                    horiz_bound.setEndX(w - 1);
-                    vert_bound.setStartX(w - 1);
-                    vert_bound.setEndX(w - 1);
-                }
-
-            });
-
-        }
-
     }
 
     @Override
@@ -607,8 +579,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         final WritableImage wimage = new WritableImage(gridStepX, gridStepY);
         SwingFXUtils.toFXImage(image, wimage);
         final ImagePattern pattern = new ImagePattern(wimage, 0, 0, gridStepX, gridStepY, false);
-
-        ((Pane) model_root.getContent()).setBackground(new Background(new BackgroundFill(pattern, CornerRadii.EMPTY, Insets.EMPTY)));
+        scroll_body.setBackground(new Background(new BackgroundFill(pattern, CornerRadii.EMPTY, Insets.EMPTY)));
     }
 
     // Future for controlling the audio player

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -172,10 +172,6 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     private static final float GRID_LINE_WIDTH = 0.222F;
 
     private Color backgroundColor = Color.WHITE;
-    private Color gridColor = Color.GRAY;
-    private int gridStepX = 20;
-    private int gridStepY = 20;
-    private boolean gridVisible = false;
     private Line horiz_bound, vert_bound;
 
     /** Constructor
@@ -426,58 +422,6 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
     }
 
     @Override
-    public void setGridColor ( WidgetColor color ) {
-
-        if ( color != null ) {
-
-            gridColor = new Color(color.getRed(), color.getGreen(), color.getBlue());
-
-            updateBackground();
-
-        }
-
-    }
-
-    @Override
-    public void setGridVisible ( Boolean visible ) {
-
-        if ( visible != null ) {
-
-            gridVisible = visible;
-
-            updateBackground();
-
-        }
-
-    }
-
-    @Override
-    public void setGridStepX ( Integer stepX ) {
-
-        if ( stepX != null ) {
-
-            gridStepX = stepX;
-
-            updateBackground();
-
-        }
-
-    }
-
-    @Override
-    public void setGridStepY ( Integer stepY ) {
-
-        if ( stepY != null ) {
-
-            gridStepY = stepY;
-
-            updateBackground();
-
-        }
-
-    }
-
-    @Override
     public void representModel(final Parent root, final DisplayModel model) throws Exception
     {
 
@@ -662,10 +606,17 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         return null;
     }
 
-    private void updateBackground() {
+    @Override
+    protected void updateBackground()
+    {
+        final boolean gridVisible = isEditMode() ? model.propGridVisible().getValue() : false;
+        final int gridStepX = model.propGridStepX().getValue(),
+                  gridStepY = model.propGridStepY().getValue();
+        final WidgetColor grid_rgb = model.propGridColor().getValue();
+        final Color gridColor = new Color(grid_rgb.getRed(), grid_rgb.getGreen(), grid_rgb.getBlue());
 
-        BufferedImage image = new BufferedImage(gridStepX, gridStepY, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D g2d = image.createGraphics();
+        final BufferedImage image = new BufferedImage(gridStepX, gridStepY, BufferedImage.TYPE_INT_ARGB);
+        final Graphics2D g2d = image.createGraphics();
 
         g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
         g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
@@ -676,21 +627,19 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         g2d.setBackground(backgroundColor);
         g2d.clearRect(0, 0, gridStepX, gridStepY);
 
-        if ( gridVisible ) {
+        if (gridVisible)
+        {
             g2d.setColor(gridColor);
             g2d.setStroke(new BasicStroke(GRID_LINE_WIDTH));
             g2d.drawLine(0, 0, gridStepX, 0);
             g2d.drawLine(0, 0, 0, gridStepY);
         }
 
-        WritableImage wimage = new WritableImage(gridStepX, gridStepY);
-
+        final WritableImage wimage = new WritableImage(gridStepX, gridStepY);
         SwingFXUtils.toFXImage(image, wimage);
-
-        ImagePattern pattern = new ImagePattern(wimage, 0, 0, gridStepX, gridStepY, false);
+        final ImagePattern pattern = new ImagePattern(wimage, 0, 0, gridStepX, gridStepY, false);
 
         ((Pane) model_root.getContent()).setBackground(new Background(new BackgroundFill(pattern, CornerRadii.EMPTY, Insets.EMPTY)));
-
     }
 
     // Future for controlling the audio player

--- a/org.csstudio.display.builder.representation.swt/src/org/csstudio/display/builder/representation/swt/SWTRepresentation.java
+++ b/org.csstudio.display.builder.representation.swt/src/org/csstudio/display/builder/representation/swt/SWTRepresentation.java
@@ -184,23 +184,4 @@ public class SWTRepresentation extends ToolkitRepresentation<Composite, Control>
     public void setDisplayWidth ( Integer width ) {
         // Not implemented
     }
-
-    /* (non-Javadoc)
-     * @see org.csstudio.display.builder.representation.ToolkitRepresentation#getDisplayHeight()
-     */
-    @Override
-    public Integer getDisplayHeight ( ) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    /* (non-Javadoc)
-     * @see org.csstudio.display.builder.representation.ToolkitRepresentation#getDisplayWidth()
-     */
-    @Override
-    public Integer getDisplayWidth ( ) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
 }

--- a/org.csstudio.display.builder.representation.swt/src/org/csstudio/display/builder/representation/swt/SWTRepresentation.java
+++ b/org.csstudio.display.builder.representation.swt/src/org/csstudio/display/builder/representation/swt/SWTRepresentation.java
@@ -174,14 +174,4 @@ public class SWTRepresentation extends ToolkitRepresentation<Composite, Control>
         logger.log(Level.WARNING, "playAudio('" + url + "') is not implemented");
         return CompletableFuture.completedFuture(false);
     }
-
-    @Override
-    public void setDisplayHeight ( Integer height ) {
-        // Not implemented
-    }
-
-    @Override
-    public void setDisplayWidth ( Integer width ) {
-        // Not implemented
-    }
 }

--- a/org.csstudio.display.builder.representation.swt/src/org/csstudio/display/builder/representation/swt/SWTRepresentation.java
+++ b/org.csstudio.display.builder.representation.swt/src/org/csstudio/display/builder/representation/swt/SWTRepresentation.java
@@ -202,16 +202,6 @@ public class SWTRepresentation extends ToolkitRepresentation<Composite, Control>
     }
 
     @Override
-    public Integer getGridStepX ( ) {
-        return 10;
-    }
-
-    @Override
-    public Integer getGridStepY ( ) {
-        return 10;
-    }
-
-    @Override
     public void setDisplayHeight ( Integer height ) {
         // Not implemented
     }

--- a/org.csstudio.display.builder.representation.swt/src/org/csstudio/display/builder/representation/swt/SWTRepresentation.java
+++ b/org.csstudio.display.builder.representation.swt/src/org/csstudio/display/builder/representation/swt/SWTRepresentation.java
@@ -80,12 +80,6 @@ public class SWTRepresentation extends ToolkitRepresentation<Composite, Control>
     }
 
     @Override
-    public void setBackground(final WidgetColor color)
-    {
-        // Not implemented
-    }
-
-    @Override
     public void representModel(final Composite shell, final DisplayModel model)
             throws Exception
     {

--- a/org.csstudio.display.builder.representation.swt/src/org/csstudio/display/builder/representation/swt/SWTRepresentation.java
+++ b/org.csstudio.display.builder.representation.swt/src/org/csstudio/display/builder/representation/swt/SWTRepresentation.java
@@ -182,26 +182,6 @@ public class SWTRepresentation extends ToolkitRepresentation<Composite, Control>
     }
 
     @Override
-    public void setGridColor ( WidgetColor color ) {
-        // Not implemented
-    }
-
-    @Override
-    public void setGridVisible ( Boolean visible ) {
-        // Not implemented
-    }
-
-    @Override
-    public void setGridStepX ( Integer gridStepX ) {
-        // Not implemented
-    }
-
-    @Override
-    public void setGridStepY ( Integer gridStepY ) {
-        // Not implemented
-    }
-
-    @Override
     public void setDisplayHeight ( Integer height ) {
         // Not implemented
     }

--- a/org.csstudio.display.builder.representation/src/org/csstudio/display/builder/representation/ToolkitRepresentation.java
+++ b/org.csstudio.display.builder.representation/src/org/csstudio/display/builder/representation/ToolkitRepresentation.java
@@ -180,19 +180,9 @@ abstract public class ToolkitRepresentation<TWP extends Object, TW> implements E
     abstract public ToolkitRepresentation<TWP, TW> openNewWindow(DisplayModel model, Consumer<DisplayModel> close_handler) throws Exception;
 
     /**
-     * @return The current display height.
-     */
-    abstract public Integer getDisplayHeight ( );
-
-    /**
      * @param height The new display height.
      */
     abstract public void setDisplayHeight ( Integer height );
-
-    /**
-     * @return The current display width.
-     */
-    abstract public Integer getDisplayWidth ( );
 
     /**
      * @param width The new display width.

--- a/org.csstudio.display.builder.representation/src/org/csstudio/display/builder/representation/ToolkitRepresentation.java
+++ b/org.csstudio.display.builder.representation/src/org/csstudio/display/builder/representation/ToolkitRepresentation.java
@@ -225,19 +225,9 @@ abstract public class ToolkitRepresentation<TWP extends Object, TW> implements E
     abstract public void setGridVisible ( Boolean visible );
 
     /**
-     * @return The current horizontal grid step size.
-     */
-    abstract public Integer getGridStepX ( );
-
-    /**
      * @param gridStepX The new horizontal grid step size.
      */
     abstract public void setGridStepX ( Integer gridStepX );
-
-    /**
-     * @return The current vertical grid step size.
-     */
-    abstract public Integer getGridStepY ( );
 
     /**
      * @param gridStepY The new vertical grid step size.


### PR DESCRIPTION
The grid display and the editor UI hint for the display size had to add getters and setters for all the grid and display size information. In principle, that information is in the DisplayModel, but the model was not accessible in the JFXRepresentation (because private in base class) nor the Tracker*Contrains (not passed in).

By changing to a 'protected model' in the TollkitRepresentation and by updating the model in the Tracker, one-caller getters and setters could be replaced by plain model property listeners.