### PR TITLE
Added SVG support.

### DIFF
--- a/org.csstudio.display.builder.feature/feature.xml
+++ b/org.csstudio.display.builder.feature/feature.xml
@@ -161,4 +161,18 @@ For details, see http://www.eclipse.org/legal/epl-v10.html
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="de.codecentric.centerdevice.javafxsvg"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.batik.transcoder"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/org.csstudio.javafx/META-INF/MANIFEST.MF
+++ b/org.csstudio.javafx/META-INF/MANIFEST.MF
@@ -7,5 +7,9 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.csstudio.javafx
 Bundle-Vendor: Kay Kasemir - SNS
+Bundle-Activator: org.csstudio.javafx.Activator
 Require-Bundle: org.csstudio.display.builder.util;bundle-version="1.0.0",
- org.eclipse.osgi
+ org.eclipse.osgi,
+ org.apache.batik.transcoder;bundle-version="1.7.0",
+ de.codecentric.centerdevice.javafxsvg;bundle-version="1.2.1"
+Bundle-ActivationPolicy: lazy

--- a/org.csstudio.javafx/src/org/csstudio/javafx/Activator.java
+++ b/org.csstudio.javafx/src/org/csstudio/javafx/Activator.java
@@ -1,37 +1,58 @@
-/*******************************************************************************
+/** *****************************************************************************
  * Copyright (c) 2015-2016 Oak Ridge National Laboratory.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *******************************************************************************/
+ ****************************************************************************** */
 package org.csstudio.javafx;
 
+
+import de.codecentric.centerdevice.javafxsvg.SvgImageLoaderFactory;
 import java.util.logging.Logger;
-
-import org.csstudio.display.builder.util.ResourceUtil;
-
 import javafx.scene.image.Image;
+import org.csstudio.display.builder.util.ResourceUtil;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
 
-/** Plugin information
- *  @author Kay Kasemir
+
+/**
+ * Plugin information
+ *
+ * @author Kay Kasemir
  */
-@SuppressWarnings("nls")
-public class Activator // Could become plugin activator
-{
-    /** Plugin ID */
+@SuppressWarnings( "nls" )
+public class Activator implements BundleActivator {
+
+    /**
+     * Plugin ID
+     */
     public static final String ID = "org.csstudio.javafx";
 
-    /** Logger for plugin */
+    /**
+     * Logger for plugin
+     */
     public static final Logger logger = Logger.getLogger(ID);
 
-    /** @param base_name Icon base name (no path, no extension)
-     *  @return Image
-     *  @throws Exception on error
+    /**
+     * @param base_name Icon base name (no path, no extension)
+     * @return Image
+     * @throws Exception on error
      */
-    public static Image getIcon(final String base_name) throws Exception
-    {
+    public static Image getIcon( final String base_name ) throws Exception {
         String path = "platform:/plugin/org.csstudio.javafx/icons/" + base_name + ".png";
         return new Image(ResourceUtil.openPlatformResource(path));
     }
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        logger.config("Installing SVG support...");
+        SvgImageLoaderFactory.install();
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+
+    }
+
 }


### PR DESCRIPTION
Prerequisite: [#44](https://github.com/ControlSystemStudio/maven-osgi-bundles/pull/44)

Added SVG support to Display Builder through the [JavaFxSVG](https://github.com/codecentric/javafxsvg) library, providing a [custom image renderer to JavaFX 8](https://blog.codecentric.de/en/2015/03/adding-custom-image-renderer-javafx-8/) supporting SVG images.