### PR TITLE
CSSTUDIO-362 font.def

### DIFF
--- a/org.csstudio.display.builder.model/examples/color.def
+++ b/org.csstudio.display.builder.model/examples/color.def
@@ -1,7 +1,7 @@
 # Named colors
 #
 # Format:
-# NameOfColor = red, green, blue [, alpha ]
+#   NameOfColor = red, green, blue [, alpha ] | PreviouslyDefinedNameOfColor
 # with values in 0..255 range.
 #
 # Whenever possible, use named colors in displays
@@ -46,7 +46,7 @@ Header_ForeGround=255,255,255
 # just because you like the look of red.
 # STOP looks similar to red=MAJOR alarm, and is allowed
 # for 'STOP' type of buttons
-STOP = 255,0,0
+STOP = MAJOR
 
 # Attention looks similar to a MINOR alarm.
 # It is meant to draw attention
@@ -62,5 +62,5 @@ Attention = 255,160,0
 # For example, a limit switch indicator could use colors "Off" and "MAJOR":
 # Off when idle, MAJOR when the limit switch was hit and this is an abnormal situation
 # that requires attention.
-On = 0,255,0
+On = OK
 Off = 60,100,60

--- a/org.csstudio.display.builder.model/examples/font.def
+++ b/org.csstudio.display.builder.model/examples/font.def
@@ -11,15 +11,22 @@
 
 // Format:
 //
-// Named Font = Family - Style - Size
+//   NamedFont['(' OS ')'] = Family '-' Style '-' Size | '@'PreviouslyDefinedNamedFont
 //
 // Family: Font family name "Liberation Sans", "Liberation Mono", "Liberation Serif"
-// Style : "regular", "bold", "italic", "bold italic"
-// Size  : Font height in pixels
+//  Style: "regular", "bold", "italic", "bold italic"
+//   Size: Font height in pixels
+//     OS: "windows", "linux", "macosx"
 //
 // Leading/trailing spaces around each element are OK, but if the font family
 // is "Liberation Sans", it has to be typed with just that one space between
 // "Liberation" and "Sans"
+//
+// Examples of named fonts
+//
+//   Default      = Liberation Sans - regular - 14
+//   Default Bold = Liberation Sans - bold    - 14
+//   Header 1     = @Default Bold
 //
 // Speaking of "Liberation Sans":
 // The display builder includes the "Liberation" fonts

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/persist/NamedWidgetColors.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/persist/NamedWidgetColors.java
@@ -116,9 +116,9 @@ public class NamedWidgetColors extends ConfigFileParser
 
         if ( optionalColor.isPresent() ) {
 
-            NamedWidgetColor nameColor = optionalColor.get();
+            NamedWidgetColor namedColor = optionalColor.get();
 
-            define(new NamedWidgetColor(name, nameColor.getRed(), nameColor.getGreen(), nameColor.getBlue(), nameColor.getAlpha()));
+            define(new NamedWidgetColor(name, namedColor.getRed(), namedColor.getGreen(), namedColor.getBlue(), namedColor.getAlpha()));
 
         } else {
 


### PR DESCRIPTION
Allows font names to be used in font.def to define other font names.

So, now the following is possible:

```
Default      = Liberation Sans - regular - 14
Default Bold = Liberation Sans - bold    - 14
Header 1     = @Default Bold
```

Updated also the color.def file to match the new parsing mechanism.