### PR TITLE
Increased the width of the cross inside the clear button.

### DIFF
--- a/org.csstudio.javafx/src/org/csstudio/javafx/ClearingTextField.java
+++ b/org.csstudio.javafx/src/org/csstudio/javafx/ClearingTextField.java
@@ -44,6 +44,7 @@ public class ClearingTextField extends TextField
 
             final Line line1 = new Line();
             line1.setStroke(Color.WHITE);
+            line1.setStrokeWidth(1.7);
             line1.startXProperty().bind(text.heightProperty().multiply(-0.1));
             line1.startYProperty().bind(text.heightProperty().multiply(-0.1));
             line1.endXProperty().bind(text.heightProperty().multiply(0.1));
@@ -51,6 +52,7 @@ public class ClearingTextField extends TextField
 
             final Line line2 = new Line();
             line2.setStroke(Color.WHITE);
+            line2.setStrokeWidth(1.7);
             line2.startXProperty().bind(text.heightProperty().multiply(0.1));
             line2.startYProperty().bind(text.heightProperty().multiply(-0.1));
             line2.endXProperty().bind(text.heightProperty().multiply(-0.1));


### PR DESCRIPTION
Hello @kasemir 
I like a lot your implementation: the clear button is much better than the other.
I just did a small change, increasing the linewidth to 1.7, using an old icon-design trick of never use 1 px wide line to represent meaningful information, but something more. Really on one of the monitors I've tested it the cross was barely visible (laptop retina display using full resolution).
Anyway, thank you for the implementation.