### PR TITLE
Focus color for transparent buttons now has alpha set to 0.1.

### DIFF
--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/properties/ScriptInfo.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/properties/ScriptInfo.java
@@ -44,6 +44,11 @@ public class ScriptInfo
     /** Script 'path' used to indicate an embedded java script */
     public final static String EMBEDDED_JAVASCRIPT = "EmbeddedJs";
 
+    /** Example java script */
+    public static final String EXAMPLE_JAVASCRIPT =
+        "logger = org.csstudio.display.builder.runtime.script.ScriptUtil.getLogger();\n" +
+        "logger.info(\"Hello\");";
+
     private final String path, text;
     private final boolean check_connections;
     private final List<ScriptPV> pvs;

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ActionsDialog.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ActionsDialog.java
@@ -549,21 +549,33 @@ public class ActionsDialog extends Dialog<ActionInfos>
         execute_script_details.add(path_box, 1, 1);
 
         final Button btn_embed_py = new Button(Messages.ScriptsDialog_BtnEmbedPy, JFXUtil.getIcon("embedded_script.png"));
-        btn_embed_py.setOnAction(event ->
-        {
+        btn_embed_py.setOnAction(event -> {
+
             execute_script_file.setText(ScriptInfo.EMBEDDED_PYTHON);
+
             final String text = execute_script_text.getText();
-            if (text == null  ||  text.trim().isEmpty())
-                execute_script_text.setText(Messages.ScriptsDialog_DefaultEmbeddedPython);
+
+            if ( text == null
+              || text.trim().isEmpty()
+              || text.trim().equals(ScriptInfo.EXAMPLE_JAVASCRIPT) ) {
+                execute_script_text.setText(ScriptInfo.EXAMPLE_PYTHON);
+            }
+
         });
 
         final Button btn_embed_js = new Button(Messages.ScriptsDialog_BtnEmbedJS, JFXUtil.getIcon("embedded_script.png"));
-        btn_embed_js.setOnAction(event ->
-        {
+        btn_embed_js.setOnAction(event -> {
+
             execute_script_file.setText(ScriptInfo.EMBEDDED_JAVASCRIPT);
+
             final String text = execute_script_text.getText();
-            if (text == null  ||  text.trim().isEmpty())
-                execute_script_text.setText(Messages.ScriptsDialog_DefaultEmbeddedJavaScript);
+
+            if ( text == null
+              || text.trim().isEmpty()
+              || text.trim().equals(ScriptInfo.EXAMPLE_PYTHON) ) {
+                execute_script_text.setText(ScriptInfo.EXAMPLE_JAVASCRIPT);
+            }
+
         });
 
         execute_script_details.add(new HBox(10, btn_embed_py, btn_embed_js), 1, 2);

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
@@ -322,37 +322,49 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
         btn_embed_py = new Button(Messages.ScriptsDialog_BtnEmbedPy, JFXUtil.getIcon("embedded_script.png"));
         btn_embed_py.setMaxWidth(Double.MAX_VALUE);
         btn_embed_py.setDisable(true);
-        btn_embed_py.setOnAction(event ->
-        {
-            if (selected_script_item.text == null  ||  selected_script_item.text.trim().isEmpty())
-                selected_script_item.text = Messages.ScriptsDialog_DefaultEmbeddedPython;
+        btn_embed_py.setOnAction(event -> {
+
+            if ( selected_script_item.text == null
+              || selected_script_item.text.trim().isEmpty()
+              || selected_script_item.text.trim().equals(ScriptInfo.EXAMPLE_JAVASCRIPT) ) {
+                selected_script_item.text = ScriptInfo.EXAMPLE_PYTHON;
+            }
 
             final MultiLineInputDialog dlg = new MultiLineInputDialog(scripts_table, selected_script_item.text);
+
             DialogHelper.positionDialog(dlg, btn_embed_py, -300, -200);
+
             final Optional<String> result = dlg.showAndWait();
-            if (result.isPresent())
-            {
+
+            if ( result.isPresent() ) {
                 selected_script_item.file.set(ScriptInfo.EMBEDDED_PYTHON);
                 selected_script_item.text = result.get();
             }
+
         });
 
         btn_embed_js = new Button(Messages.ScriptsDialog_BtnEmbedJS, JFXUtil.getIcon("embedded_script.png"));
         btn_embed_js.setMaxWidth(Double.MAX_VALUE);
         btn_embed_js.setDisable(true);
-        btn_embed_js.setOnAction(event ->
-        {
-            if (selected_script_item.text == null  ||  selected_script_item.text.trim().isEmpty())
-                selected_script_item.text = Messages.ScriptsDialog_DefaultEmbeddedJavaScript;
+        btn_embed_js.setOnAction(event -> {
+
+            if ( selected_script_item.text == null
+              || selected_script_item.text.trim().isEmpty()
+              || selected_script_item.text.trim().equals(ScriptInfo.EXAMPLE_PYTHON) ) {
+                selected_script_item.text = ScriptInfo.EXAMPLE_JAVASCRIPT;
+            }
 
             final MultiLineInputDialog dlg = new MultiLineInputDialog(scripts_table, selected_script_item.text);
+
             DialogHelper.positionDialog(dlg, btn_embed_js, -300, -200);
+
             final Optional<String> result = dlg.showAndWait();
-            if (result.isPresent())
-            {
+
+            if ( result.isPresent() ) {
                 selected_script_item.file.set(ScriptInfo.EMBEDDED_JAVASCRIPT);
                 selected_script_item.text = result.get();
             }
+
         });
 
         final VBox buttons = new VBox(10, add, remove,

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
@@ -314,7 +314,7 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
     {
         foreground = JFXUtil.convert(model_widget.propForegroundColor().getValue());
         if (model_widget.propTransparent().getValue())
-            background = "-fx-background: transparent; -fx-color: transparent";
+            background = "-fx-background: transparent; -fx-color: transparent; -fx-focus-color: rgba(3,158,211,0.1);";
         else
             background = JFXUtil.shadedStyle(model_widget.propBackgroundColor().getValue());
     }


### PR DESCRIPTION
Without this change, when you press a transparent button it became opaque blue, i.e. the focus color cover the entire button because the background color is transparent.

Setting the alpha component of the focus color to 0.1, the focused button become partially transparent, showing what is placed under it.

The rgb components of `rgba(3,158,211,0.1)` correspond to `#039ED3`, the original value for `-fx-focus-color`.