### PR TITLE
#286 dialogs issues: more enhancements in Scripts dialog.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/LineNumberCellFactory.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/LineNumberCellFactory.java
@@ -1,0 +1,64 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * Copyright (C) 2016 European Spallation Source ERIC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.csstudio.display.builder.representation.javafx;
+
+
+import javafx.geometry.Pos;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.util.Callback;
+
+
+/**
+ * A generic cell factory you can simply use to display the row number in a
+ * table.
+ *
+ * @param T The type of the TableView generic type (i.e. T == TableView<T>)
+ * @param E The type of the content in all cells in this TableColumn.
+ * @author claudiorosati, European Spallation Source ERIC
+ * @version 1.0.0 24 Jan 2018
+ */
+public class LineNumberCellFactory<T, E> implements Callback<TableColumn<T, E>, TableCell<T, E>> {
+
+    private final boolean startFromZero;
+
+    /**
+     * @param startFromZero {@code true} if row numbers must be shown starting
+     *            from 0, {@code false} starting from 1.
+     */
+    public LineNumberCellFactory ( boolean startFromZero ) {
+        this.startFromZero = startFromZero;
+    }
+
+    @Override
+    public TableCell<T, E> call ( TableColumn<T, E> param ) {
+        return new TableCell<T, E>() {
+
+            /* Instance initializer. */
+            {
+                setAlignment(Pos.CENTER_LEFT);
+            }
+
+            @Override
+            protected void updateItem ( E item, boolean empty ) {
+
+                super.updateItem(item, empty);
+
+                if ( !empty ) {
+                    setText(String.valueOf(getTableRow().getIndex() + ( startFromZero ? 0 : 1 )));
+                } else {
+                    setText("");
+                }
+
+            }
+
+        };
+    }
+
+}

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
@@ -37,6 +37,7 @@ import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
+import javafx.geometry.Pos;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
@@ -369,6 +370,7 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
         // Buttons
         final Button add = new Button(Messages.Add, JFXUtil.getIcon("add.png"));
         add.setMaxWidth(Double.MAX_VALUE);
+        add.setAlignment(Pos.CENTER_LEFT);
         add.setOnAction(event ->
         {
             final ScriptItem newItem = new ScriptItem();
@@ -385,6 +387,7 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
 
         btn_script_remove = new Button(Messages.Remove, JFXUtil.getIcon("delete.png"));
         btn_script_remove.setMaxWidth(Double.MAX_VALUE);
+        btn_script_remove.setAlignment(Pos.CENTER_LEFT);
         btn_script_remove.setDisable(true);
         btn_script_remove.setOnAction(event ->
         {
@@ -398,6 +401,7 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
 
         btn_file = new Button(Messages.ScriptsDialog_BtnFile, JFXUtil.getIcon("open_file.png"));
         btn_file.setMaxWidth(Double.MAX_VALUE);
+        btn_file.setAlignment(Pos.CENTER_LEFT);
         btn_file.setDisable(true);
         btn_file.setOnAction(event ->
         {
@@ -425,6 +429,7 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
 
         btn_embed_py = new Button(Messages.ScriptsDialog_BtnEmbedPy, JFXUtil.getIcon("embedded_script.png"));
         btn_embed_py.setMaxWidth(Double.MAX_VALUE);
+        btn_embed_py.setAlignment(Pos.CENTER_LEFT);
         btn_embed_py.setDisable(true);
         btn_embed_py.setOnAction(event ->
         {
@@ -445,6 +450,7 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
 
         btn_embed_js = new Button(Messages.ScriptsDialog_BtnEmbedJS, JFXUtil.getIcon("embedded_script.png"));
         btn_embed_js.setMaxWidth(Double.MAX_VALUE);
+        btn_embed_js.setAlignment(Pos.CENTER_LEFT);
         btn_embed_js.setDisable(true);
         btn_embed_js.setOnAction(event ->
         {
@@ -468,6 +474,7 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
                                           btn_file, btn_embed_py, btn_embed_js);
         final HBox content = new HBox(10, scripts_table, buttons);
         HBox.setHgrow(scripts_table, Priority.ALWAYS);
+        HBox.setHgrow(buttons, Priority.NEVER);
         return content;
     }
 
@@ -610,6 +617,7 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
         // Buttons
         btn_pv_add = new Button(Messages.Add, JFXUtil.getIcon("add.png"));
         btn_pv_add.setMaxWidth(Double.MAX_VALUE);
+        btn_pv_add.setAlignment(Pos.CENTER_LEFT);
         btn_pv_add.setOnAction(event ->
         {
             final PVItem newItem = new PVItem("", true);
@@ -625,6 +633,7 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
 
         btn_pv_remove = new Button(Messages.Remove, JFXUtil.getIcon("delete.png"));
         btn_pv_remove.setMaxWidth(Double.MAX_VALUE);
+        btn_pv_remove.setAlignment(Pos.CENTER_LEFT);
         btn_pv_remove.setDisable(true);
         btn_pv_remove.setOnAction(event ->
         {
@@ -638,11 +647,13 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
 
         btn_pv_up = new Button(Messages.MoveUp, JFXUtil.getIcon("up.png"));
         btn_pv_up.setMaxWidth(Double.MAX_VALUE);
+        btn_pv_up.setAlignment(Pos.CENTER_LEFT);
         btn_pv_up.setDisable(true);
         btn_pv_up.setOnAction(event -> TableHelper.move_item_up(pvs_table, pv_items));
 
         btn_py_down = new Button(Messages.MoveDown, JFXUtil.getIcon("down.png"));
         btn_py_down.setMaxWidth(Double.MAX_VALUE);
+        btn_py_down.setAlignment(Pos.CENTER_LEFT);
         btn_py_down.setDisable(true);
         btn_py_down.setOnAction(event -> TableHelper.move_item_down(pvs_table, pv_items));
 
@@ -656,6 +667,7 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
         final VBox buttons = new VBox(10, btn_pv_add, btn_pv_remove, btn_pv_up, btn_py_down);
         final HBox pvs_buttons = new HBox(10, pvs_table, buttons);
         HBox.setHgrow(pvs_table, Priority.ALWAYS);
+        HBox.setHgrow(buttons, Priority.NEVER);
 
         final VBox content = new VBox(10, pvs_buttons, btn_check_connections);
         VBox.setVgrow(pvs_buttons, Priority.ALWAYS);

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
@@ -584,6 +584,15 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
     /** @return Node for UI elements that edit the PVs of a script */
     private Region createPVsTable()
     {
+
+        final TableColumn<PVItem, Integer> indexColumn = new TableColumn<>("#");
+
+        indexColumn.setEditable(false);
+        indexColumn.setSortable(false);
+        indexColumn.setCellFactory(new LineNumberCellFactory<>(true));
+        indexColumn.setMaxWidth(26);
+        indexColumn.setMinWidth(26);
+
         // Create table with editable 'name' column
         pvs_name_col = new TableColumn<>(Messages.ScriptsDialog_ColPV);
         pvs_name_col.setSortable(false);
@@ -603,10 +612,10 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
         pvs_trigger_col.setResizable(false);
         pvs_trigger_col.setMaxWidth(70);
         pvs_trigger_col.setMinWidth(70);
-        pvs_trigger_col.setPrefWidth(70);
 
         // Table column for 'trigger' uses CheckBoxTableCell that directly modifies the Observable Property
         pvs_table = new TableView<>(pv_items);
+        pvs_table.getColumns().add(indexColumn);
         pvs_table.getColumns().add(pvs_name_col);
         pvs_table.getColumns().add(pvs_trigger_col);
         pvs_table.setEditable(true);

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
@@ -575,6 +575,7 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
     {
         // Create table with editable 'name' column
         pvs_name_col = new TableColumn<>(Messages.ScriptsDialog_ColPV);
+        pvs_name_col.setSortable(false);
         pvs_name_col.setCellValueFactory(new PropertyValueFactory<PVItem, String>("name"));
         pvs_name_col.setCellFactory((col) -> new AutoCompletedTableCell(menu));
         pvs_name_col.setOnEditCommit(event ->
@@ -585,6 +586,7 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
         });
 
         pvs_trigger_col = new TableColumn<>(Messages.ScriptsDialog_ColTrigger);
+        pvs_trigger_col.setSortable(false);
         pvs_trigger_col.setCellValueFactory(new PropertyValueFactory<PVItem, Boolean>("trigger"));
         pvs_trigger_col.setCellFactory(CheckBoxTableCell.<PVItem>forTableColumn(pvs_trigger_col));
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
@@ -589,15 +589,19 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
         pvs_trigger_col.setSortable(false);
         pvs_trigger_col.setCellValueFactory(new PropertyValueFactory<PVItem, Boolean>("trigger"));
         pvs_trigger_col.setCellFactory(CheckBoxTableCell.<PVItem>forTableColumn(pvs_trigger_col));
+        pvs_trigger_col.setResizable(false);
+        pvs_trigger_col.setMaxWidth(70);
+        pvs_trigger_col.setMinWidth(70);
+        pvs_trigger_col.setPrefWidth(70);
 
-        final Preferences pref = Preferences.userNodeForPackage(getClass());
-        final double nameColumnWidth = pref.getDouble("pvs_table.pvs_name_col.width", -1);
-        if (nameColumnWidth > 0)
-            pvs_name_col.setPrefWidth(nameColumnWidth);
-
-        final double triggerColumnWidth = pref.getDouble("pvs_table.pvs_trigger_col.width", -1);
-        if (triggerColumnWidth > 0)
-            pvs_trigger_col.setPrefWidth(triggerColumnWidth);
+//        final Preferences pref = Preferences.userNodeForPackage(getClass());
+//        final double nameColumnWidth = pref.getDouble("pvs_table.pvs_name_col.width", -1);
+//        if (nameColumnWidth > 0)
+//            pvs_name_col.setPrefWidth(nameColumnWidth);
+//
+//        final double triggerColumnWidth = pref.getDouble("pvs_table.pvs_trigger_col.width", -1);
+//        if (triggerColumnWidth > 0)
+//            pvs_trigger_col.setPrefWidth(triggerColumnWidth);
 
         // Table column for 'trigger' uses CheckBoxTableCell that directly modifies the Observable Property
         pvs_table = new TableView<>(pv_items);


### PR DESCRIPTION
- Removed the possibility to sort columns in PVs table, in order to keep the natural order used to refer to them.
- PVs Table's trigger column mad not resizable.
- Removed saving/restoring the size of the PVs Table's name column width.
- Added SplitPane as main container. Split divider position is saved/restored.
- Left-aligned buttons content.
- Added row numbers to PVs Table. This should make easier to identify the index of the PV to be used in scripts.