### PR TITLE
Issue #286: rules dialog

### DIFF
--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/RulesDialog.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/RulesDialog.java
@@ -640,7 +640,7 @@ public class RulesDialog extends Dialog<List<RuleInfo>>
 
         ruleSplitPane.setOrientation(Orientation.HORIZONTAL);
         ruleSplitPane.setDividerPositions(prefRSPDividerPosition);
-        ruleSplitPane.setStyle("-fx-padding: 0;-fx-border-color: null; -fx-border-insets: 0;-fx-background-insets: 0, 0;");
+        ruleSplitPane.setStyle("-fx-background-insets: 0, 0;");
 
         VBox.setVgrow(ruleSplitPane, Priority.ALWAYS);
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ModalityHack.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ModalityHack.java
@@ -7,75 +7,37 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx;
 
-import java.util.concurrent.TimeUnit;
 
-import org.csstudio.display.builder.model.util.ModelThreadPool;
-
-import javafx.application.Platform;
 import javafx.scene.control.Dialog;
 import javafx.stage.Stage;
 import javafx.stage.Window;
 
-/** Most awful terrible no good hack for Modality
+
+/**
+ * Less awful terrible no good hack than before for Modality
+ * <p>
+ * When hosted inside SWT, the modality of JavaFX Dialogs,
+ * {@link Dialog#initModality()},
+ * is ignored with respect to SWT windows.
+ * The dialog can end up below the SWT window,
+ * and the application then appears stuck because it is awaiting
+ * a result from closing the dialog.
+ * <p>
+ * This hack move the dialog always in front.
  *
- *  <p>When hosted inside SWT, the modality of JavaFX Dialogs,
- *  {@link Dialog#initModality()},
- *  is ignored with respect to SWT windows.
- *  The dialog can end up below the SWT window,
- *  and the application then appears stuck because it is awaiting
- *  a result from closing the dialog.
- *
- *  <p>This hack periodically moves the dialog
- *  to the front.
- *
- *  @author Kay Kasemir
+ * @author Kay Kasemir
+ * @author Claudio Rosati
  */
-public class ModalityHack implements Runnable
-{
-    public static ModalityHack forDialog(final Dialog<?> dialog)
-    {
+public class ModalityHack {
+
+    public static void forDialog ( final Dialog<?> dialog ) {
+
         final Window window = dialog.getDialogPane().getContent().getScene().getWindow();
-        if (! (window instanceof Stage))
-            return null;
 
-        final ModalityHack hack = new ModalityHack((Stage) window);
-        dialog.setOnHiding(event -> hack.stop());
-        return hack;
+        if ( window instanceof Stage ) {
+            ( (Stage) window ).setAlwaysOnTop(true);
+        }
+
     }
 
-    private static final int MS_DELAY = 1500;
-
-    /** Stage to keep at front.
-     *  Set to <code>null</code> when no longer in use.
-     */
-    private Stage stage;
-
-    private ModalityHack(final Stage stage)
-    {
-        this.stage = stage;
-        schedule();
-    }
-
-    private void stop()
-    {
-        stage = null;
-    }
-
-    private void schedule()
-    {
-        // Schedule another update, a little later, on UI thread.
-        ModelThreadPool.getTimer().schedule(() -> Platform.runLater(this), MS_DELAY, TimeUnit.MILLISECONDS);
-    }
-
-    @Override
-    public void run()
-    {
-        final Stage safe_stage = stage;
-        if (safe_stage == null)
-            return;
-        if (safe_stage.isShowing())
-            safe_stage.toFront();
-        // Schedule another check
-        schedule();
-    }
 }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
@@ -22,6 +22,7 @@ import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.properties.ScriptInfo;
 import org.csstudio.display.builder.model.properties.ScriptPV;
 import org.csstudio.display.builder.model.util.ModelThreadPool;
+import org.csstudio.display.builder.representation.javafx.widgets.JFXBaseRepresentation;
 import org.csstudio.javafx.DialogHelper;
 import org.csstudio.javafx.LineNumberTableCellFactory;
 import org.csstudio.javafx.SyntaxHighlightedMultiLineInputDialog;
@@ -42,6 +43,7 @@ import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
+import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.CheckBox;
@@ -220,6 +222,10 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
 
         setTitle(Messages.ScriptsDialog_Title);
         setHeaderText(Messages.ScriptsDialog_Info);
+
+        final Node node = JFXBaseRepresentation.getJFXNode(widget);
+
+        initOwner(node.getScene().getWindow());
 
         scripts.forEach(script -> script_items.add(ScriptItem.forInfo(script)));
         fixupScripts(0);

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
@@ -189,4 +189,5 @@
 /* Original split pane divider is too thick. */
 .split-pane > .split-pane-divider {
     -fx-padding: 0 0.095em 0 0.095em;
+    -fx-color: derive(-fx-base,-11.11%);
 }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
@@ -186,3 +186,7 @@
     -fx-font-size: 10pt;
 }
 
+/* Original split pane divider is too thick. */
+.split-pane > .split-pane-divider {
+    -fx-padding: 0 0.095em 0 0.095em;
+}


### PR DESCRIPTION
Started reworking the Rules dialog.

@kasemir 
I've hugely simplified the ModalityHack class, removing the scheduled task in favour of the simpler `((Stage) window).setAlwaysOnTop(true)`. The advantages are that instead of having dialogs popping up here and there, they just stay on top of everything.

I've tested it on MacOS X and our CentOS 7.3 linux reference machine, and to me it seems working well (and it seems satisfy my stakeholders). Can you please test it and check if this change is OK for you too?