### PR TITLE
On getting focus, editable combo boxes will select the existing text

### DIFF
--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -278,7 +278,13 @@ public class PropertyPanelSection extends GridPane
 
             field.focusedProperty().addListener(( ob, o, focused ) -> {
                 if ( focused ) {
+
                     combo.requestFocus();
+
+                    if ( combo.isEditable() ) {
+                        combo.getEditor().selectAll();
+                    }
+
                 }
             });
 
@@ -321,6 +327,7 @@ public class PropertyPanelSection extends GridPane
                 if ( focused ) {
                     if ( combo.isVisible() ) {
                         combo.requestFocus();
+                        combo.getEditor().selectAll();
                     } else if ( check.isVisible() ) {
                         check.requestFocus();
                     }


### PR DESCRIPTION
If the combo box is not editable, then it only requests focus. This manner using the UP/DOWN arrow keys will be possible to select the previous/following item in the combo box.