### PR TITLE
CSSTUDIO-558: Added rotation to Symbol and TextSymbol widgets.

### DIFF
--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/SymbolWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/SymbolWidget.java
@@ -10,6 +10,7 @@ package org.csstudio.display.builder.model.widgets;
 
 
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newBooleanPropertyDescriptor;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newDoublePropertyDescriptor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newFilenamePropertyDescriptor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.newIntegerPropertyDescriptor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBackgroundColor;
@@ -66,6 +67,7 @@ public class SymbolWidget extends PVWidget {
 
     public static final WidgetPropertyDescriptor<Integer>                       propInitialIndex  = newIntegerPropertyDescriptor (WidgetPropertyCategory.DISPLAY,  "initial_index",  Messages.WidgetProperties_InitialIndex, 0, Integer.MAX_VALUE);
     public static final WidgetPropertyDescriptor<Boolean>                       propShowIndex     = newBooleanPropertyDescriptor (WidgetPropertyCategory.DISPLAY,  "show_index",     Messages.WidgetProperties_ShowIndex);
+    public static final WidgetPropertyDescriptor<Double>                        propRotation      = newDoublePropertyDescriptor  (WidgetPropertyCategory.DISPLAY,  "rotation",       Messages.WidgetProperties_Rotation);
 
     public static final WidgetPropertyDescriptor<Integer>                       propArrayIndex    = newIntegerPropertyDescriptor (WidgetPropertyCategory.BEHAVIOR, "array_index",    Messages.WidgetProperties_ArrayIndex, 0, Integer.MAX_VALUE);
     public static final WidgetPropertyDescriptor<Boolean>                       propAutoSize      = newBooleanPropertyDescriptor (WidgetPropertyCategory.BEHAVIOR, "auto_size",      Messages.WidgetProperties_AutoSize);
@@ -85,6 +87,7 @@ public class SymbolWidget extends PVWidget {
     private volatile WidgetProperty<Boolean>                     enabled;
     private volatile WidgetProperty<Integer>                     initial_index;
     private volatile WidgetProperty<Boolean>                     preserve_ratio;
+    private volatile WidgetProperty<Double>                      rotation;
     private volatile WidgetProperty<Boolean>                     show_index;
     private volatile ArrayWidgetProperty<WidgetProperty<String>> symbols;
     private volatile WidgetProperty<Boolean>                     transparent;
@@ -145,6 +148,10 @@ public class SymbolWidget extends PVWidget {
         return preserve_ratio;
     }
 
+    public WidgetProperty<Double> propRotation ( ) {
+        return rotation;
+    }
+
     public WidgetProperty<Boolean> propShowIndex ( ) {
         return show_index;
     }
@@ -166,6 +173,7 @@ public class SymbolWidget extends PVWidget {
 
         properties.add(background     = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
         properties.add(initial_index  = propInitialIndex.createProperty(this, 0));
+        properties.add(rotation       = propRotation.createProperty(this, 0.0));
         properties.add(show_index     = propShowIndex.createProperty(this, false));
         properties.add(transparent    = propTransparent.createProperty(this, true));
 

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/TextSymbolWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/TextSymbolWidget.java
@@ -15,8 +15,10 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFont;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propHorizontalAlignment;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propRotationStep;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propTransparent;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propVerticalAlignment;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propWrapWords;
 
 import java.util.Collections;
 import java.util.List;
@@ -33,6 +35,7 @@ import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.NamedWidgetFonts;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.properties.HorizontalAlignment;
+import org.csstudio.display.builder.model.properties.RotationStep;
 import org.csstudio.display.builder.model.properties.VerticalAlignment;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.properties.WidgetFont;
@@ -70,14 +73,16 @@ public class TextSymbolWidget extends PVWidget {
     );
 
     private volatile WidgetProperty<Integer>                     array_index;
-    private volatile WidgetProperty<Boolean>                     enabled;
-    private volatile WidgetProperty<WidgetColor>                 foreground;
     private volatile WidgetProperty<WidgetColor>                 background;
-    private volatile WidgetProperty<Boolean>                     transparent;
+    private volatile WidgetProperty<Boolean>                     enabled;
     private volatile WidgetProperty<WidgetFont>                  font;
+    private volatile WidgetProperty<WidgetColor>                 foreground;
     private volatile WidgetProperty<HorizontalAlignment>         horizontal_alignment;
+    private volatile WidgetProperty<RotationStep>                rotation_step;
     private volatile ArrayWidgetProperty<WidgetProperty<String>> symbols;
+    private volatile WidgetProperty<Boolean>                     transparent;
     private volatile WidgetProperty<VerticalAlignment>           vertical_alignment;
+    private volatile WidgetProperty<Boolean>                     wrap_words;
 
     public TextSymbolWidget ( ) {
         super(WIDGET_DESCRIPTOR.getType(), 32, 32);
@@ -107,6 +112,10 @@ public class TextSymbolWidget extends PVWidget {
         return horizontal_alignment;
     }
 
+    public WidgetProperty<RotationStep> propRotationStep ( ) {
+        return rotation_step;
+    }
+
     public ArrayWidgetProperty<WidgetProperty<String>> propSymbols ( ) {
         return symbols;
     }
@@ -119,6 +128,10 @@ public class TextSymbolWidget extends PVWidget {
         return vertical_alignment;
     }
 
+    public WidgetProperty<Boolean> propWrapWords ( ) {
+        return wrap_words;
+    }
+
     @Override
     protected void defineProperties ( final List<WidgetProperty<?>> properties ) {
 
@@ -126,12 +139,14 @@ public class TextSymbolWidget extends PVWidget {
 
         properties.add(symbols              = propSymbols.createProperty(this, Collections.emptyList()));
 
-        properties.add(background           = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
         properties.add(font                 = propFont.createProperty(this, NamedWidgetFonts.DEFAULT));
         properties.add(foreground           = propForegroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.TEXT)));
-        properties.add(horizontal_alignment = propHorizontalAlignment.createProperty(this, HorizontalAlignment.CENTER));
+        properties.add(background           = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
         properties.add(transparent          = propTransparent.createProperty(this, true));
+        properties.add(horizontal_alignment = propHorizontalAlignment.createProperty(this, HorizontalAlignment.CENTER));
         properties.add(vertical_alignment   = propVerticalAlignment.createProperty(this, VerticalAlignment.MIDDLE));
+        properties.add(rotation_step        = propRotationStep.createProperty(this, RotationStep.NONE));
+        properties.add(wrap_words           = propWrapWords.createProperty(this, true));
 
         properties.add(array_index          = propArrayIndex.createProperty(this, 0));
         properties.add(enabled              = propEnabled.createProperty(this, true));

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -86,6 +86,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
     private volatile boolean                     enabled               = true;
     private final List<Image>                    imagesList            = Collections.synchronizedList(new ArrayList<>(4));
     private final Map<String, Image>             imagesMap             = Collections.synchronizedMap(new TreeMap<>());
+    private BorderPane                           imagePane;
     private final WidgetPropertyListener<String> imagePropertyListener = this::imageChanged;
     private ImageView                            imageView;
     private Label                                indexLabel;
@@ -269,6 +270,12 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
                 jfx_node.setBackground(new Background(new BackgroundFill(JFXUtil.convert(model_widget.propBackgroundColor().getValue()), CornerRadii.EMPTY, Insets.EMPTY)));
             }
 
+            value = model_widget.propRotation().getValue();
+
+            if ( !Objects.equals(value, imagePane.getRotate()) ) {
+                imagePane.setRotate((double) value);
+            }
+
         }
 
         if ( dirtyValue.checkAndClear() && updatingValue.compareAndSet(false, true) ) {
@@ -333,7 +340,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
 
         AnchorPane symbol = new AnchorPane();
 
-            BorderPane imagePane = new BorderPane();
+            imagePane = new BorderPane();
 
                 imageView = new ImageView();
 
@@ -349,6 +356,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
             imagePane.setCenter(imageView);
             imagePane.setPrefWidth(model_widget.propWidth().getValue());
             imagePane.setPrefHeight(model_widget.propHeight().getValue());
+            imagePane.setRotate(model_widget.propRotation().getValue());
 
             AnchorPane.setLeftAnchor(imagePane, 0.0);
             AnchorPane.setRightAnchor(imagePane, 0.0);
@@ -423,6 +431,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
         model_widget.propBackgroundColor().addUntypedPropertyListener(this::styleChanged);
         model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
         model_widget.propPreserveRatio().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propRotation().addUntypedPropertyListener(this::styleChanged);
         model_widget.propShowIndex().addUntypedPropertyListener(this::styleChanged);
         model_widget.propTransparent().addUntypedPropertyListener(this::styleChanged);
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TextSymbolRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TextSymbolRepresentation.java
@@ -19,6 +19,7 @@ import java.util.logging.Level;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.WidgetPropertyListener;
+import org.csstudio.display.builder.model.properties.RotationStep;
 import org.csstudio.display.builder.model.widgets.TextSymbolWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.csstudio.javafx.Styles;
@@ -37,6 +38,8 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.CornerRadii;
+import javafx.scene.transform.Rotate;
+import javafx.scene.transform.Translate;
 
 
 /**
@@ -54,6 +57,13 @@ public class TextSymbolRepresentation extends RegionBaseRepresentation<Label, Te
     private int                                  symbolIndex            = -1;
     private final WidgetPropertyListener<String> symbolPropertyListener = this::symbolChanged;
     private final AtomicBoolean                  updatingValue          = new AtomicBoolean(false);
+    /**
+     * Was there ever any transformation applied to the jfx_node?
+     *  <p>Used to optimize:
+     *  If there never was a rotation, don't even _clear()_ it
+     *  to keep the Node's nodeTransformation == null
+     */
+    private boolean                              was_ever_transformed   = false;
 
     @Override
     public void updateChanges ( ) {
@@ -93,6 +103,34 @@ public class TextSymbolRepresentation extends RegionBaseRepresentation<Label, Te
 
         if ( dirtyStyle.checkAndClear() ) {
 
+            final int width = model_widget.propWidth().getValue();
+            final int height = model_widget.propHeight().getValue();
+            final RotationStep rotation = model_widget.propRotationStep().getValue();
+
+            switch ( rotation ) {
+                case NONE:
+                    jfx_node.setPrefSize(width, height);
+                    if ( was_ever_transformed ) {
+                        jfx_node.getTransforms().clear();
+                    }
+                    break;
+                case NINETY:
+                    jfx_node.setPrefSize(height, width);
+                    jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()), new Translate(-height, 0));
+                    was_ever_transformed = true;
+                    break;
+                case ONEEIGHTY:
+                    jfx_node.setPrefSize(width, height);
+                    jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()), new Translate(-width, -height));
+                    was_ever_transformed = true;
+                    break;
+                case MINUS_NINETY:
+                    jfx_node.setPrefSize(height, width);
+                    jfx_node.getTransforms().setAll(new Rotate(-rotation.getAngle()), new Translate(0, -width));
+                    was_ever_transformed = true;
+                    break;
+            }
+
             value = model_widget.propEnabled().getValue();
 
             if ( !Objects.equals(value, enabled) ) {
@@ -110,6 +148,7 @@ public class TextSymbolRepresentation extends RegionBaseRepresentation<Label, Te
             );
             jfx_node.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
             jfx_node.setTextFill(JFXUtil.convert(model_widget.propForegroundColor().getValue()));
+            jfx_node.setWrapText(model_widget.propWrapWords().getValue());
 
         }
 
@@ -201,13 +240,15 @@ public class TextSymbolRepresentation extends RegionBaseRepresentation<Label, Te
         model_widget.propWidth().addUntypedPropertyListener(this::geometryChanged);
         model_widget.propHeight().addUntypedPropertyListener(this::geometryChanged);
 
+        model_widget.propBackgroundColor().addUntypedPropertyListener(this::styleChanged);
         model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
         model_widget.propForegroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::styleChanged);
         model_widget.propFont().addUntypedPropertyListener(this::styleChanged);
         model_widget.propHorizontalAlignment().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propRotationStep().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propTransparent().addUntypedPropertyListener(this::styleChanged);
         model_widget.propVerticalAlignment().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propWrapWords().addUntypedPropertyListener(this::styleChanged);
 
         if ( toolkit.isEditMode() ) {
             dirtyValue.checkAndClear();


### PR DESCRIPTION
@kasemir 
I was asked to add rotation to symbol and text symbol widgets.

Text symbol widget rotation was made copying the label one.

I received complains about the rotation of the Picture widget, because the size of the actual rotated picture cannot be defined (unless inverting the roto-scale matrix used internally). To be honest, I don't like too the current picture rotation implementation, being not so intuitive. For this reason, I switched to the simplest implementation (JavaFX rotate) because in this way the width and height of the widget are also the ones of the image, then rotation is applied (this was the requirements from my stakeholders).