### PR TITLE
CSSTUDIO-579: ConcurrentModificationException modifying PV names in Rules and/or Scripts dialog.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/AutocompleteMenu.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/AutocompleteMenu.java
@@ -290,12 +290,15 @@ public class AutocompleteMenu
         if (updater != null)
             updater.updateHistory(entry);
         else
-        {   // add entry to top of menu items (for the particular autocomplete menu instance)
-            // (Currently, there are two instances of this class in the editor: one for the inline editor, one for the palette)
-            final List<MenuItem> items = menu.getItems();
-            // remove entry if present, to avoid duplication
-            items.removeIf((item) -> item.getText().equals(entry));
-            items.add(0, createMenuItem(entry));
+        {
+            Platform.runLater(() -> {
+                // add entry to top of menu items (for the particular autocomplete menu instance)
+                // (Currently, there are two instances of this class in the editor: one for the inline editor, one for the palette)
+                final List<MenuItem> items = menu.getItems();
+                // remove entry if present, to avoid duplication
+                items.removeIf((item) -> item.getText().equals(entry));
+                items.add(0, createMenuItem(entry));
+            });
         }
     }
 


### PR DESCRIPTION
It seems to me this can be the only possible source of the problem, now wrapped into a Platform.runLater call.

The exception was thrown at org.csstudio.display.builder.representation.javafx.AutocompleteMenu.lambda$1(AutocompleteMenu.java:279).

Difficult to reproduce: I had some randomly (on macOS X), some of my colleagues have the problem more often (on Linux VM).