### PR TITLE
Fixed asymmetry in button's text.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
@@ -43,7 +43,7 @@
  */
 .action_button
 {
-    -fx-padding: 0em 0em 0em 0.2em;
+    -fx-padding: 0em 0.1em 0em 0.1em;
     -fx-wrap-text: true;
     -fx-text-overrun: clip;
     -fx-text-alignment: center;


### PR DESCRIPTION
Before:

<img width="106" alt="before" src="https://user-images.githubusercontent.com/10833922/36595307-f9799224-18a1-11e8-9a7b-0f33ac19c483.png">

After:

<img width="106" alt="after" src="https://user-images.githubusercontent.com/10833922/36595318-ff7cf076-18a1-11e8-8763-23c0505096f1.png">
