### PR TITLE
SVG image loading

### DIFF
--- a/org.csstudio.display.builder.feature/feature.xml
+++ b/org.csstudio.display.builder.feature/feature.xml
@@ -176,13 +176,6 @@ For details, see http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="de.codecentric.centerdevice.javafxsvg"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.apache.batik.transcoder"
          download-size="0"
          install-size="0"
@@ -222,6 +215,13 @@ For details, see http://www.eclipse.org/legal/epl-v10.html
          download-size="0"
          install-size="0"
          version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="de.codecentric.centerdevice.javafxsvg"
+         download-size="0"
+         install-size="0"
+         version="1.2.1"
          unpack="false"/>
 
 </feature>

--- a/org.csstudio.javafx/META-INF/MANIFEST.MF
+++ b/org.csstudio.javafx/META-INF/MANIFEST.MF
@@ -11,9 +11,9 @@ Bundle-Activator: org.csstudio.javafx.Activator
 Require-Bundle: org.csstudio.display.builder.util;bundle-version="1.0.0",
  org.eclipse.osgi,
  org.apache.xmlgraphics.batik-transcoder;bundle-version="1.8.0",
- de.codecentric.centerdevice.javafxsvg,
+ de.codecentric.centerdevice.javafxsvg;bundle-version="1.2.1",
  org.reactfx,
- org.fxmisc.flowless, 
+ org.fxmisc.flowless,
  org.fxmisc.richtext.fx,
  org.fxmisc.undo.fx,
  org.fxmisc.wellbehaved.fx


### PR DESCRIPTION
JavaFxSVG ver. 1.3.0 introduced a mechanism to load images in their original size, not the default 400x400 of ver. 1.2.1.
This new version cannot be used because of Eclipse clashing when loading batik SVG DOM factory (JavaFxSVG requires batik 1.8, but somewhere else in maven-osgi-bundles batik 1.7 is used).
For this reason, I made explicit the version needed by Display Builder (1.2.1), until a fix in maven-osgi-bundles is performed.