### PR TITLE
CSSTUDIO-588: changing group style

### DIFF
--- a/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/CreateGroupAction.java
+++ b/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/CreateGroupAction.java
@@ -17,6 +17,7 @@ import org.csstudio.display.builder.model.ChildrenProperty;
 import org.csstudio.display.builder.model.ModelPlugin;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.widgets.GroupWidget;
+import org.csstudio.display.builder.model.widgets.GroupWidget.Style;
 import org.csstudio.display.builder.util.undo.UndoableActionManager;
 import org.eclipse.jface.action.Action;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
@@ -55,9 +56,11 @@ public class CreateGroupAction extends Action
 
         // Inset depends on representation and changes with group style and font.
         // Can be obtained via group.runtimePropInsets() _after_ the group has
-        // been represented, but right now this guess is based on the
-        // JFX GroupRepresentation with group box and default font
-        final int inset = 16;
+        // been represented. For this reason Style.NONE is used, where the inset
+        // is always 0. An alternative could be Style.LINE, with an inset of 1.
+        final int inset = 0;
+        group.propStyle().setValue(Style.NONE);
+        group.propTransparent().setValue(true);
         group.propX().setValue((int) rect.getMinX() - inset);
         group.propY().setValue((int) rect.getMinY() - inset);
         group.propWidth().setValue((int) rect.getWidth() + 2*inset);

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/properties/InsetsWidgetProperty.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/properties/InsetsWidgetProperty.java
@@ -38,6 +38,17 @@ public class InsetsWidgetProperty extends RuntimeWidgetProperty<int[]>
             return new InsetsWidgetProperty(widget, default_value);
         }
     };
+    public static final WidgetPropertyDescriptor<int[]> runtimePropExtendedInsets =
+        new WidgetPropertyDescriptor<int[]>(
+            WidgetPropertyCategory.RUNTIME, "insets", Messages.WidgetProperties_Insets)
+    {
+        @Override
+        public WidgetProperty<int[]> createProperty(final Widget widget,
+                final int[] default_value)
+        {
+            return new InsetsWidgetProperty(widget, default_value, 4);
+        }
+    };
 
     /** Get insets of a container
      *
@@ -52,25 +63,32 @@ public class InsetsWidgetProperty extends RuntimeWidgetProperty<int[]>
         return null;
     }
 
-    public InsetsWidgetProperty(final Widget widget, final int[] default_value)
+    private final int validSize;
+
+    private InsetsWidgetProperty ( final Widget widget, final int[] default_value ) {
+        this(widget, default_value, 2);
+    }
+
+    private InsetsWidgetProperty(final Widget widget, final int[] default_value, int validSize)
     {
         super(runtimePropInsets, widget, default_value);
+        this.validSize = validSize;
     }
 
     @Override
     protected int[] restrictValue(final int[] requested_value)
     {
-        if (requested_value.length != 2)
-            throw new IllegalArgumentException("Need int[2], got " + requested_value);
+        if (requested_value.length != validSize)
+            throw new IllegalArgumentException("Need int[" + validSize + "], got " + requested_value);
         return requested_value;
     }
 
     @Override
     public void setValueFromObject(final Object value) throws Exception
     {
-        if (value instanceof int[]  &&  ((int[]) value).length == 2)
+        if (value instanceof int[]  &&  ((int[]) value).length == validSize)
             setValue((int[]) value);
         else
-            throw new Exception("Need int[2], got " + value);
+            throw new Exception("Need int[" + validSize + "], got " + value);
     }
 }

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/GroupWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/GroupWidget.java
@@ -12,7 +12,7 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMacros;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propTransparent;
-import static org.csstudio.display.builder.model.properties.InsetsWidgetProperty.runtimePropInsets;
+import static org.csstudio.display.builder.model.properties.InsetsWidgetProperty.runtimePropExtendedInsets;
 
 import java.util.Arrays;
 import java.util.List;
@@ -203,7 +203,7 @@ public class GroupWidget extends VisibleWidget
         properties.add(foreground = propForegroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.TEXT)));
         properties.add(background = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
         properties.add(transparent = propTransparent.createProperty(this, false));
-        properties.add(insets = runtimePropInsets.createProperty(this, new int[] { 0, 0 }));
+        properties.add(insets = runtimePropExtendedInsets.createProperty(this, new int[] { 0, 0, 0, 0 }));
     }
 
     @Override

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
@@ -140,7 +140,9 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
 
             System.arraycopy(model_widget.runtimePropInsets().getValue(), 0, insets, 0, insets.length);
 
-            if ( !model_widget.runtimeChildren().getValue().isEmpty() ) {
+            boolean hasChildren = !model_widget.runtimeChildren().getValue().isEmpty();
+
+            if ( hasChildren ) {
 
                 inner.relocate(- insets[0], - insets[1]);
 
@@ -197,9 +199,9 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
 
                     jfx_node.setBorder(new Border(new BorderStroke(foreground_color, BorderStrokeStyle.SOLID, CornerRadii.EMPTY, BorderWidths.DEFAULT)));
                     label.setVisible(true);
-                    label.relocate(firstUpdate ? 0 : BORDER_WIDTH, BORDER_WIDTH);
+                    label.relocate(0, BORDER_WIDTH);
                     label.setPadding(TITLE_PADDING);
-                    label.setPrefSize(width, inset);
+                    label.setPrefSize(width + ( ( !firstUpdate && hasChildren ) ? insets[2] : 0 ), inset);
                     label.setTextFill(background_color);
                     label.setBackground(new Background(new BackgroundFill(foreground_color, CornerRadii.EMPTY, Insets.EMPTY)));
 
@@ -233,7 +235,7 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
 
             if ( firstUpdate ) {
                 firstUpdate = false;
-            } else if ( !model_widget.runtimeChildren().getValue().isEmpty() ) {
+            } else if ( hasChildren ) {
 
                 x -= insets[0];
                 y -= insets[1];

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.widgets;
 
+import java.util.Arrays;
+
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
@@ -27,12 +29,26 @@ import javafx.scene.layout.BorderWidths;
 import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
+import javafx.scene.shape.StrokeLineCap;
+import javafx.scene.shape.StrokeLineJoin;
+import javafx.scene.shape.StrokeType;
 
 /** Creates JavaFX item for model widget
  *  @author Kay Kasemir
  */
 public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget>
 {
+
+    private static final BorderWidths EDTI_NONE_BORDER = new BorderWidths(0.5, 0.5, 0.5, 0.5, false, false, false, false);
+    public static final BorderStrokeStyle EDTI_NONE_DASHED = new BorderStrokeStyle(
+        StrokeType.INSIDE,
+        StrokeLineJoin.MITER,
+        StrokeLineCap.BUTT,
+        10,
+        0,
+        Arrays.asList(Double.valueOf(11.11), Double.valueOf(7.7), Double.valueOf(3.3), Double.valueOf(7.7))
+    );
+
     private final DirtyFlag dirty_border = new DirtyFlag();
 
     private static final int border_width = 1;
@@ -120,8 +136,8 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
             {
                 inset = 0;
                 // In edit mode, show outline because otherwise hard to handle the totally invisible group
-                if (toolkit.isEditMode() && model_widget.propTransparent().getValue())
-                    jfx_node.setBorder(new Border(new BorderStroke(foreground_color, BorderStrokeStyle.DASHED, CornerRadii.EMPTY, BorderWidths.DEFAULT)));
+                if (toolkit.isEditMode())
+                    jfx_node.setBorder(new Border(new BorderStroke(foreground_color, EDTI_NONE_DASHED, CornerRadii.EMPTY, EDTI_NONE_BORDER)));
                 else
                     jfx_node.setBorder(null);
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
@@ -112,6 +112,9 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
             label.setFont(JFXUtil.convert(font));
             label.setText(model_widget.propName().getValue());
 
+            final double previousX = inner.getLayoutX();
+            final double previousY = inner.getLayoutY();
+
             final Style style = model_widget.propStyle().getValue();
             if (style == Style.NONE)
             {
@@ -126,6 +129,8 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
 
                 inner.relocate(0, 0);
                 model_widget.runtimePropInsets().setValue(new int[] { 0, 0 });
+System.out.println("**** " + style.name() + ": " + 0 + ", " + 0);
+
             }
             else if (style == Style.TITLE)
             {
@@ -140,6 +145,7 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
 
                 inner.relocate(border_width, inset+border_width);
                 model_widget.runtimePropInsets().setValue(new int[] { border_width, inset+border_width });
+System.out.println("**** " + style.name() + ": " + border_width + ", " + ( inset + border_width ));
             }
             else if (style == Style.LINE)
             {
@@ -150,6 +156,7 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
 
                 inner.relocate(border_width, border_width);
                 model_widget.runtimePropInsets().setValue(new int[] { border_width, border_width });
+System.out.println("**** " + style.name() + ": " + border_width + ", " + border_width);
             }
             else // GROUP
             {
@@ -164,6 +171,7 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
 
                 inner.relocate(inset, inset);
                 model_widget.runtimePropInsets().setValue(new int[] { inset, inset });
+System.out.println("**** " + style.name() + ": " + inset + ", " + inset);
             }
         }
     }


### PR DESCRIPTION
Updated the way groups handle the style change: basically when a group has no children, then it  doesn't resize when the style changes. Instead, when there are children the group is resized and repositioned to maintain the children at their user's perceived location.

To obtain that result, the following changes were made:

- when a group is created around some selected widgets, its initial style is now NONE and transparent (this is similar to what done by programs like KeyNote, PowerPoint, OmniGraffle, Visio, Illustrator, etc.). This is necessary because a predictable insets its needed independently of the default font used for the title;
- when the style is NONE, the special sub-pixel, dashed border is always drawn in editor mode (see picture);
- when visible, the title has a pad around it to avoid touching the surroundings.

![groups](https://user-images.githubusercontent.com/10833922/37411954-499794d4-27a4-11e8-8dcb-9559a09bd341.png)

In my experience helping integrators in designing (or validating) their OPI, I always need transparent NONE groups to just organise and easily move widgets. But if it is absolutely necessary to create an opaque GROUP border when wrapping widgets, then in the CreateGroupAction a change in style can be executed with delay in the event thread (I think it should work), and the `group.propTransparent().setValue(true);` statement removed.
