### PR TITLE
CSSTUDIO-636: Combo box not retriggering PV write

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
@@ -11,6 +11,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.WidgetProperty;
@@ -22,7 +23,10 @@ import org.diirt.vtype.VEnum;
 import org.diirt.vtype.VType;
 
 import javafx.collections.FXCollections;
+import javafx.event.ActionEvent;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.ListCell;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.text.Font;
 
 /** Creates JavaFX item for model widget
@@ -61,6 +65,36 @@ public class ComboRepresentation extends RegionBaseRepresentation<ComboBox<Strin
                     toolkit.fireWrite(model_widget, value);
                 }
             });
+
+            combo.setCellFactory(list -> {
+
+                final ListCell<String> cell = new ListCell<String>() {
+                    @Override
+                    public void updateItem ( String item, boolean empty ) {
+
+                        super.updateItem(item, empty);
+
+                        if ( !empty ) {
+                            setText(item);
+                        }
+
+                    }
+                };
+
+                cell.addEventFilter(MouseEvent.MOUSE_PRESSED, e -> {
+                    if ( Objects.equals(combo.getValue(), cell.getItem()) ) {
+                        combo.fireEvent(new ActionEvent());
+                        //  Alternatively...
+                        //combo.setValue(null);
+                        //combo.getSelectionModel().select(cell.getItem());
+                        e.consume();
+                    }
+                });
+
+                return cell;
+
+            });
+
         }
         return combo;
     }


### PR DESCRIPTION
Combo box is not retriggering a PV write if the same element is (re)selected. This commit patches the behaviour.

@kasemir Do you think a specific property must be added to the Combo Widget, or can we have it as default behaviour?