### PR TITLE
CSSTUDIO-618: limits from PV not working in Spinner.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseGaugeRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseGaugeRepresentation.java
@@ -444,6 +444,13 @@ public abstract class BaseGaugeRepresentation<W extends BaseGaugeWidget> extends
         //  Model's values.
         double newMin = model_widget.propMinimum().getValue();
         double newMax = model_widget.propMaximum().getValue();
+
+        //  If invalid limits, fall back to 0..100 range.
+        if ( Double.isNaN(newMin) || Double.isNaN(newMax) || newMin > newMax ) {
+            newMin = 0.0;
+            newMax = 100.0;
+        }
+
         double newLoLo = model_widget.propLevelLoLo().getValue();
         double newLow = model_widget.propLevelLow().getValue();
         double newHigh = model_widget.propLevelHigh().getValue();
@@ -455,12 +462,20 @@ public abstract class BaseGaugeRepresentation<W extends BaseGaugeWidget> extends
             final Display display_info = ValueUtil.displayOf(model_widget.runtimePropValue().getValue());
 
             if ( display_info != null ) {
-                newMin = display_info.getLowerDisplayLimit();
-                newMax = display_info.getUpperDisplayLimit();
+
+                double infoMin = display_info.getLowerCtrlLimit();
+                double infoMax = display_info.getUpperCtrlLimit();
+
+                if ( !Double.isNaN(infoMin) && !Double.isNaN(infoMax) && infoMin < infoMax ) {
+                    newMin = infoMin;
+                    newMax = infoMax;
+                }
+
                 newLoLo = display_info.getLowerAlarmLimit();
                 newLow = display_info.getLowerWarningLimit();
                 newHigh = display_info.getUpperWarningLimit();
                 newHiHi = display_info.getUpperAlarmLimit();
+
             }
 
         }
@@ -476,12 +491,6 @@ public abstract class BaseGaugeRepresentation<W extends BaseGaugeWidget> extends
         }
         if ( !model_widget.propShowHiHi().getValue() ) {
             newHiHi = Double.NaN;
-        }
-
-        //  If invalid limits, fall back to 0..100 range.
-        if ( !( Double.isNaN(newMin) || Double.isNaN(newMax) || newMin < newMax ) ) {
-            newMin = 0.0;
-            newMax = 100.0;
         }
 
         if ( Double.compare(min, newMin) != 0 ) {

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseKnobRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseKnobRepresentation.java
@@ -453,6 +453,13 @@ public abstract class BaseKnobRepresentation<C extends Knob, W extends KnobWidge
         //  Model's values.
         double newMin = model_widget.propMinimum().getValue();
         double newMax = model_widget.propMaximum().getValue();
+
+        //  If invalid limits, fall back to 0..100 range.
+        if ( Double.isNaN(newMin) || Double.isNaN(newMax) || newMin > newMax ) {
+            newMin = 0.0;
+            newMax = 100.0;
+        }
+
         double newLoLo = model_widget.propLevelLoLo().getValue();
         double newLow = model_widget.propLevelLow().getValue();
         double newHigh = model_widget.propLevelHigh().getValue();
@@ -464,12 +471,20 @@ public abstract class BaseKnobRepresentation<C extends Knob, W extends KnobWidge
             final Display display_info = ValueUtil.displayOf(model_widget.runtimePropValue().getValue());
 
             if ( display_info != null ) {
-                newMin = display_info.getLowerCtrlLimit();
-                newMax = display_info.getUpperCtrlLimit();
+
+                double infoMin = display_info.getLowerCtrlLimit();
+                double infoMax = display_info.getUpperCtrlLimit();
+
+                if ( !Double.isNaN(infoMin) && !Double.isNaN(infoMax) && infoMin < infoMax ) {
+                    newMin = infoMin;
+                    newMax = infoMax;
+                }
+
                 newLoLo = display_info.getLowerAlarmLimit();
                 newLow = display_info.getLowerWarningLimit();
                 newHigh = display_info.getUpperWarningLimit();
                 newHiHi = display_info.getUpperAlarmLimit();
+
             }
 
         }
@@ -485,12 +500,6 @@ public abstract class BaseKnobRepresentation<C extends Knob, W extends KnobWidge
         }
         if ( !model_widget.propShowHiHi().getValue() ) {
             newHiHi = Double.NaN;
-        }
-
-        //  If invalid limits, fall back to 0..100 range.
-        if ( !( Double.isNaN(newMin) || Double.isNaN(newMax) || newMin < newMax ) ) {
-            newMin = 0.0;
-            newMax = 100.0;
         }
 
         if ( Double.compare(min, newMin) != 0 ) {

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
@@ -17,8 +17,10 @@ import org.csstudio.display.builder.model.util.FormatOptionHandler;
 import org.csstudio.display.builder.model.widgets.SpinnerWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.csstudio.javafx.Styles;
+import org.diirt.vtype.Display;
 import org.diirt.vtype.VNumber;
 import org.diirt.vtype.VType;
+import org.diirt.vtype.ValueUtil;
 
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectPropertyBase;
@@ -47,7 +49,9 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<Stri
     private final DirtyFlag dirty_content = new DirtyFlag();
 
     protected volatile String value_text = "<?>";
-    protected volatile VType value = null;
+    protected volatile VType  value      = null;
+    private volatile double   value_max  = 100.0;
+    private volatile double   value_min  = 0.0;
 
     @Override
     protected final Spinner<String> createJFXNode() throws Exception
@@ -111,14 +115,12 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<Stri
         final String text = jfx_node.getEditor().getText();
         Object value =
                 FormatOptionHandler.parse(model_widget.runtimePropValue().getValue(), text, model_widget.propFormat().getValue());
-        double min = model_widget.propMinimum().getValue();
-        double max = model_widget.propMaximum().getValue();
         if (value instanceof Number)
         {
-            if (((Number)value).doubleValue() < min)
-                value = min;
-            else if (((Number)value).doubleValue() > max)
-                value = max;
+            if (((Number)value).doubleValue() < value_min)
+                value = value_min;
+            else if (((Number)value).doubleValue() > value_max)
+                value = value_max;
         }
         logger.log(Level.FINE, "Writing '" + text + "' as " + value + " (" + value.getClass().getName() + ")");
         toolkit.fireWrite(model_widget, value);
@@ -323,13 +325,14 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<Stri
         model_widget.propIncrement().addUntypedPropertyListener(this::behaviorChanged);
         model_widget.propMinimum().addUntypedPropertyListener(this::behaviorChanged);
         model_widget.propMaximum().addUntypedPropertyListener(this::behaviorChanged);
+        model_widget.propLimitsFromPV().addUntypedPropertyListener(this::behaviorChanged);
 
         model_widget.propFormat().addUntypedPropertyListener(this::contentChanged);
         model_widget.propPrecision().addUntypedPropertyListener(this::contentChanged);
         model_widget.runtimePropValue().addUntypedPropertyListener(this::contentChanged);
 
-        contentChanged(null, null, null);
         behaviorChanged(null, null, null);
+        contentChanged(null, null, null);
     }
 
     @Override
@@ -346,18 +349,28 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<Stri
 
     private void behaviorChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
     {
-        final TextSpinnerValueFactory factory = (TextSpinnerValueFactory)jfx_node.getValueFactory();
-        factory.setStepIncrement(model_widget.propIncrement().getValue());
-        factory.setMin(model_widget.propMinimum().getValue());
-        factory.setMax(model_widget.propMaximum().getValue());
-    }
 
+        updateLimits();
+
+        final TextSpinnerValueFactory factory = (TextSpinnerValueFactory) jfx_node.getValueFactory();
+
+        factory.setStepIncrement(model_widget.propIncrement().getValue());
+        factory.setMin(value_min);
+        factory.setMax(value_max);
+
+    }
 
     private void contentChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
     {
+
+        if ( model_widget.propLimitsFromPV().getValue() ) {
+            behaviorChanged(null, null, null);
+        }
+
         value = model_widget.runtimePropValue().getValue();
         value_text = computeText(value);
         scheduleContentUpdate();
+
     }
 
     private void scheduleContentUpdate()
@@ -400,4 +413,56 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<Stri
 
         }
     }
+
+    /**
+     * Updates, if required, the limits and zones.
+     *
+     * @return {@code true} is something changed and and UI update is required.
+     */
+    private boolean updateLimits ( ) {
+
+        boolean somethingChanged = false;
+
+        //  Model's values.
+        double newMin = model_widget.propMinimum().getValue();
+        double newMax = model_widget.propMaximum().getValue();
+
+        //  If invalid limits, fall back to 0..100 range.
+        if ( Double.isNaN(newMin) || Double.isNaN(newMax) || newMin > newMax ) {
+            newMin = 0.0;
+            newMax = 100.0;
+        }
+
+        if ( model_widget.propLimitsFromPV().getValue() ) {
+
+            //  Try to get display range from PV.
+            final Display display_info = ValueUtil.displayOf(model_widget.runtimePropValue().getValue());
+
+            if ( display_info != null ) {
+
+                double infoMin = display_info.getLowerCtrlLimit();
+                double infoMax = display_info.getUpperCtrlLimit();
+
+                if ( !Double.isNaN(infoMin) && !Double.isNaN(infoMax) && infoMin < infoMax ) {
+                    newMin = infoMin;
+                    newMax = infoMax;
+                }
+
+            }
+
+        }
+
+        if ( Double.compare(value_min, newMin) != 0 ) {
+            value_min = newMin;
+            somethingChanged = true;
+        }
+        if ( Double.compare(value_max, newMax) != 0 ) {
+            value_max = newMax;
+            somethingChanged = true;
+        }
+
+        return somethingChanged;
+
+    }
+
 }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ThumbWheelRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ThumbWheelRepresentation.java
@@ -49,7 +49,6 @@ public class ThumbWheelRepresentation extends RegionBaseRepresentation<ThumbWhee
     private volatile double     min           = 0.0;
     private final AtomicBoolean updatingValue = new AtomicBoolean(false);
 
-    @SuppressWarnings( "unchecked" )
     @Override
     public void updateChanges ( ) {
 
@@ -285,22 +284,29 @@ public class ThumbWheelRepresentation extends RegionBaseRepresentation<ThumbWhee
         double newMin = model_widget.propMinimum().getValue();
         double newMax = model_widget.propMaximum().getValue();
 
+        //  If invalid limits, fall back to 0..100 range.
+        if ( Double.isNaN(newMin) || Double.isNaN(newMax) || newMin > newMax ) {
+            newMin = 0.0;
+            newMax = 100.0;
+        }
+
         if ( model_widget.propLimitsFromPV().getValue() ) {
 
             //  Try to get display range from PV.
             final Display display_info = ValueUtil.displayOf(model_widget.runtimePropValue().getValue());
 
             if ( display_info != null ) {
-                newMin = display_info.getLowerCtrlLimit();
-                newMax = display_info.getUpperCtrlLimit();
+
+                double infoMin = display_info.getLowerCtrlLimit();
+                double infoMax = display_info.getUpperCtrlLimit();
+
+                if ( !Double.isNaN(infoMin) && !Double.isNaN(infoMax) && infoMin < infoMax ) {
+                    newMin = infoMin;
+                    newMax = infoMax;
+                }
+
             }
 
-        }
-
-        //  If invalid limits, fall back to 0..100 range.
-        if ( !( Double.isNaN(newMin) || Double.isNaN(newMax) || newMin < newMax ) ) {
-            newMin = 0.0;
-            newMax = 100.0;
         }
 
         if ( Double.compare(min, newMin) != 0 ) {


### PR DESCRIPTION
- Added code to Spinner widget dealing with limits_from_pv.
- Fixed error conditions checking in Knob, Thumb Wheel and Meter/Gauge widgets.