### PR TITLE
Updated to Eclipse 4.7 Oxygen.

### DIFF
--- a/org.csstudio.display.builder.feature/feature.xml
+++ b/org.csstudio.display.builder.feature/feature.xml
@@ -176,13 +176,6 @@ For details, see http://www.eclipse.org/legal/epl-v10.html
          unpack="false"/>
 
    <plugin
-         id="org.apache.batik.transcoder"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.fxmisc.flowless"
          download-size="0"
          install-size="0"
@@ -215,13 +208,6 @@ For details, see http://www.eclipse.org/legal/epl-v10.html
          download-size="0"
          install-size="0"
          version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="de.codecentric.centerdevice.javafxsvg"
-         download-size="0"
-         install-size="0"
-         version="1.2.1"
          unpack="false"/>
 
 </feature>

--- a/org.csstudio.javafx/META-INF/MANIFEST.MF
+++ b/org.csstudio.javafx/META-INF/MANIFEST.MF
@@ -10,8 +10,6 @@ Bundle-Vendor: Kay Kasemir - SNS
 Bundle-Activator: org.csstudio.javafx.Activator
 Require-Bundle: org.csstudio.display.builder.util;bundle-version="1.0.0",
  org.eclipse.osgi,
- org.apache.xmlgraphics.batik-transcoder;bundle-version="1.8.0",
- de.codecentric.centerdevice.javafxsvg;bundle-version="1.2.1",
  org.reactfx,
  org.fxmisc.flowless,
  org.fxmisc.richtext.fx,

--- a/org.csstudio.javafx/src/org/csstudio/javafx/Activator.java
+++ b/org.csstudio.javafx/src/org/csstudio/javafx/Activator.java
@@ -8,7 +8,6 @@
 package org.csstudio.javafx;
 
 
-import de.codecentric.centerdevice.javafxsvg.SvgImageLoaderFactory;
 import java.util.logging.Logger;
 import javafx.scene.image.Image;
 import org.csstudio.display.builder.util.ResourceUtil;
@@ -46,9 +45,8 @@ public class Activator implements BundleActivator {
 
     @Override
     public void start(BundleContext context) throws Exception {
-        logger.config("Installing SVG support...");
-        SvgImageLoaderFactory.install();
-    }
+
+	}
 
     @Override
     public void stop(BundleContext context) throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -214,12 +214,12 @@
         </repository>
         <repository>
           <id>Eclipse</id>
-          <url>http://download.eclipse.org/releases/neon</url>
+          <url>http://download.eclipse.org/releases/oxygen</url>
           <layout>p2</layout>
         </repository>
         <repository>
           <id>orbit</id>
-          <url>http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository</url>
+          <url>http://download.eclipse.org/tools/orbit/downloads/drops/R20180330011457/repository</url>
           <layout>p2</layout>
         </repository>
       </repositories>

--- a/repository/display_runtime.product
+++ b/repository/display_runtime.product
@@ -32,9 +32,6 @@
       <plugin id="javax.mail"/>
       <plugin id="javax.xml"/>
       <plugin id="net.sf.py4j"/>
-      <plugin id="org.apache.batik.css"/>
-      <plugin id="org.apache.batik.util"/>
-      <plugin id="org.apache.batik.util.gui"/>
       <plugin id="org.apache.commons.io"/>
       <plugin id="org.apache.commons.jxpath"/>
       <plugin id="org.apache.commons.lang3"/>


### PR DESCRIPTION
- Removed batik-related dependencies (SVG no more handled by batik and javafxsvg) because of an exception trying to load at Display startup of a `com.sun.xxx` library.

**Note:** it is better to perform this merge after #372, so that OPIs using SVG will still work using the new implementation provided by that pull request.