### PR TITLE
Restoring syntax highlight

### DIFF
--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/RulesDialog.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/RulesDialog.java
@@ -38,7 +38,8 @@ import org.csstudio.display.builder.representation.javafx.widgets.JFXBaseReprese
 import org.csstudio.display.builder.util.undo.UndoableActionManager;
 import org.csstudio.javafx.DialogHelper;
 import org.csstudio.javafx.LineNumberTableCellFactory;
-import org.csstudio.javafx.MultiLineInputDialog;
+import org.csstudio.javafx.SyntaxHighlightedMultiLineInputDialog;
+import org.csstudio.javafx.SyntaxHighlightedMultiLineInputDialog.Language;
 import org.csstudio.javafx.TableHelper;
 
 import javafx.application.Platform;
@@ -815,13 +816,13 @@ public class RulesDialog extends Dialog<List<RuleInfo>>
             if (sel >= 0)
             {
                 final String content = rule_items.get(sel).getRuleInfo().getTextPy(attached_widget);
-//                final SyntaxHighlightedMultiLineInputDialog dialog = new SyntaxHighlightedMultiLineInputDialog(
-//                        btn_show_script,
-//                        content,
-//                        Language.Python,
-//                        false
-//                    );
-                final MultiLineInputDialog dialog = new MultiLineInputDialog(btn_show_script, content);
+                final SyntaxHighlightedMultiLineInputDialog dialog = new SyntaxHighlightedMultiLineInputDialog(
+                    btn_show_script,
+                    content,
+                    Language.Python,
+                    false
+                );
+//                final MultiLineInputDialog dialog = new MultiLineInputDialog(btn_show_script, content);
                 DialogHelper.positionDialog(dialog, btn_show_script, -200, -300);
                 dialog.setTextHeight(600);
                 dialog.show();

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/ScriptsDialog.java
@@ -26,6 +26,8 @@ import org.csstudio.display.builder.representation.javafx.widgets.JFXBaseReprese
 import org.csstudio.javafx.DialogHelper;
 import org.csstudio.javafx.LineNumberTableCellFactory;
 import org.csstudio.javafx.MultiLineInputDialog;
+import org.csstudio.javafx.SyntaxHighlightedMultiLineInputDialog;
+import org.csstudio.javafx.SyntaxHighlightedMultiLineInputDialog.Language;
 import org.csstudio.javafx.TableHelper;
 
 import javafx.application.Platform;
@@ -643,11 +645,11 @@ public class ScriptsDialog extends Dialog<List<ScriptInfo>>
             {
                 Platform.runLater(() ->
                 {
-//                    final Language language = ScriptInfo.isJython(selected_script_item.getScriptInfo().getPath())
-//                                            ? Language.Python : Language.JavaScript;
-//                    final SyntaxHighlightedMultiLineInputDialog dlg = new SyntaxHighlightedMultiLineInputDialog(
-//                        scripts_table, selected_script_item.text, language);
-                    final MultiLineInputDialog dlg = new MultiLineInputDialog(scripts_table, selected_script_item.text);
+                    final Language language = ScriptInfo.isJython(selected_script_item.getScriptInfo().getPath())
+                                            ? Language.Python : Language.JavaScript;
+                    final SyntaxHighlightedMultiLineInputDialog dlg = new SyntaxHighlightedMultiLineInputDialog(
+                        scripts_table, selected_script_item.text, language);
+//                    final MultiLineInputDialog dlg = new MultiLineInputDialog(scripts_table, selected_script_item.text);
                     DialogHelper.positionDialog(dlg, btn_edit, -300, -200);
                     dlg.showAndWait().ifPresent(result -> selected_script_item.text = result);
                 });


### PR DESCRIPTION
It works on Eclipse 4.7 Oxygen inside the [ESS product](https://github.com/ControlSystemStudio/org.csstudio.ess.product).