### PR TITLE
CSSTUDIO-691: SVG displayed outside bounds.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
@@ -262,10 +262,10 @@ public class PictureRepresentation extends JFXBaseRepresentation<Group, PictureW
         }
         if (dirty_style.checkAndClear())
         {
-            Integer widg_w = model_widget.propWidth().getValue();
-            Integer widg_h = model_widget.propHeight().getValue();
-            double pic_w = widg_w.doubleValue();
-            double pic_h = widg_h.doubleValue();
+            double widg_w = model_widget.propWidth().getValue().doubleValue();
+            double widg_h = model_widget.propHeight().getValue().doubleValue();
+            double pic_w = widg_w;
+            double pic_h = widg_h;
 
             // preserve aspect ratio
             if (!model_widget.propStretch().getValue())
@@ -315,14 +315,22 @@ public class PictureRepresentation extends JFXBaseRepresentation<Group, PictureW
             if ( svg != null ) {
 
                 Bounds bounds = svg.getLayoutBounds();
-                double scale_x = final_pic_w / bounds.getWidth();
-                double scale_y = final_pic_h / bounds.getHeight();
+                double boundsWidth = bounds.getWidth();
+                double boundsHeight = bounds.getHeight();
+                double scale_x = final_pic_w / boundsWidth;
+                double scale_y = final_pic_h / boundsWidth;
 
                 svg.setScaleX(scale_x);
                 svg.setScaleY(scale_y);
 
-                translate.setX((widg_w - final_pic_w) / 2.0);
-                translate.setY((widg_h - final_pic_h) / 2.0);
+                if ( final_pic_w < boundsWidth ) {
+                    translate.setX(( widg_w - boundsWidth ) / 2.0);
+                }
+
+                if ( final_pic_h < boundsHeight ) {
+                    translate.setY(( widg_h - boundsHeight ) / 2.0);
+                }
+
                 jfx_node.relocate(model_widget.propX().getValue(), model_widget.propY().getValue());
 
             }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -361,10 +361,10 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
         if ( needsSVGResize ) {
             imagesList.stream().filter(ic -> ic.isSVG()).forEach(ic -> {
 
-                Integer widgetWidth = model_widget.propWidth().getValue();
-                Integer widgetHeight = model_widget.propHeight().getValue();
-                double symbolWidth = widgetWidth.doubleValue();
-                double symbolHeight = widgetHeight.doubleValue();
+                double widgetWidth = model_widget.propWidth().getValue().doubleValue();
+                double widgetHeight = model_widget.propHeight().getValue().doubleValue();
+                double symbolWidth = widgetWidth;
+                double symbolHeight = widgetHeight;
 
                 if ( model_widget.propPreserveRatio().getValue() ) {
 
@@ -394,9 +394,23 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
 
                 SVGContent svg = ic.getSVG();
                 Bounds bounds = svg.getLayoutBounds();
+                double boundsWidth = bounds.getWidth();
+                double boundsHeight = bounds.getHeight();
 
-                svg.setScaleX(finalSymbolWidth / bounds.getWidth());
-                svg.setScaleY(finalSymbolHeight / bounds.getHeight());
+                svg.setScaleX(finalSymbolWidth / boundsWidth);
+                svg.setScaleY(finalSymbolHeight / boundsHeight);
+
+                if ( finalSymbolWidth < boundsWidth && widgetWidth <= boundsWidth ) {
+                    svg.setTranslateX(( widgetWidth - boundsWidth ) / 2.0);
+                } else {
+                    svg.setTranslateX(0);
+                }
+
+                if ( finalSymbolHeight < boundsHeight && widgetHeight <= boundsHeight ) {
+                    svg.setTranslateY(( widgetHeight - boundsHeight ) / 2.0);
+                } else {
+                    svg.setTranslateY(0);
+                }
 
             });
         }


### PR DESCRIPTION
SVG are represented as a Group node. Their preferred width and height is fixed (the size of the content) and cannot be changed. This creates a problem when rescaling to a size lower than the preferred one.

Using translation this solve the problem only when rotation is 0 (current fix, making ESS integrators happy for now).

To solve the problem completely I need more time and I want to think about having SVG loaded as Containers, or adding to SVGContent a methods that set the preferred size, performing the rescaling accordingly.