### PR TITLE
CSSTUDIO-658: Stage set always on top.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXStageRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXStageRepresentation.java
@@ -56,6 +56,7 @@ public class JFXStageRepresentation extends JFXRepresentation
         setSceneStyle(scene);
         stage.setScene(scene);
         stage.setOnCloseRequest((WindowEvent event) -> handleCloseRequest(scene, close_request_handler));
+        stage.setAlwaysOnTop(true);
         stage.show();
 
         // If ScenicView.jar is added to classpath, open it here


### PR DESCRIPTION
My integrators lament the fact that when an action opens a DB OPI it can be covered by the main application window, and then lost forever.

I've fixed it setting the stage always on top, working on MacOS X and Linux (CentOS 7.4).

I've also prepared a more complex solution, having an "Always On Top" check box enabled when "Standalone" is selected on Actions dialog. But I don't know if it is really worth the changes (in many files).