### PR TITLE
Location saved and restored from preferences.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXStageRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXStageRepresentation.java
@@ -7,8 +7,11 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx;
 
+import java.text.MessageFormat;
 import java.util.function.Consumer;
 import java.util.logging.Level;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
 
 import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.representation.ToolkitRepresentation;
@@ -35,34 +38,61 @@ public class JFXStageRepresentation extends JFXRepresentation
         this.stage = stage;
     }
 
-    /** Configure an existing Stage
-     *  @param model Model that provides stage size
-     *  @param close_request_handler Close request handler that will be hooked to stage's close handler
-     *  @return Top-level Parent
+    /**
+     * Configure an existing Stage
+     *
+     * @param model Model that provides stage size
+     * @param close_request_handler Close request handler that will be hooked to
+     *            stage's close handler
+     * @return Top-level Parent
      */
-    public Parent configureStage(final DisplayModel model, final Consumer<DisplayModel> close_request_handler)
-    {
-        stage.setTitle(model.getDisplayName());
-        stage.setX(model.propX().getValue());
-        stage.setY(model.propY().getValue());
+    public Parent configureStage ( final DisplayModel model, final Consumer<DisplayModel> close_request_handler ) {
+
+        final String name = model.getDisplayName();
+
+        stage.setTitle(name);
+
+        //  The following trick is necessary because keys cannot be longer than 80 characters.
+        final String hexName = Integer.toHexString(name.hashCode()).toLowerCase();
+        final String xPrefName = MessageFormat.format("stage.window.{0}.x", hexName);
+        final String yPrefName = MessageFormat.format("stage.window.{0}.y", hexName);
+        final Preferences pref = Preferences.userNodeForPackage(JFXStageRepresentation.class);
+
+        stage.setX(pref.getDouble(xPrefName, model.propX().getValue()));
+        stage.setY(pref.getDouble(yPrefName,model.propY().getValue()));
+        stage.setOnHidden(event -> {
+
+            pref.putDouble(xPrefName, stage.getX());
+            pref.putDouble(yPrefName, stage.getY());
+
+            try {
+                pref.flush();
+            } catch ( BackingStoreException ex ) {
+                logger.log(Level.WARNING, "Unable to flush preferences", ex);
+            }
+
+        });
 
         ScrollPane modelRoot = createModelRoot();
-        final int width = Math.max(80, model.propWidth().getValue());
-        final int height = Math.max(60, model.propHeight().getValue());
+        final double width = Math.max(80, 1.2 + model.propWidth().getValue());
+        final double height = Math.max(60, 1.2 + model.propHeight().getValue());
 
-        modelRoot.setPrefSize(1.2 + model.propWidth().getValue(), 1.2 + model.propHeight().getValue());
+        modelRoot.setPrefSize(width, height);
 
         final Scene scene = new Scene(modelRoot);
+
         setSceneStyle(scene);
+
         stage.setScene(scene);
-        stage.setOnCloseRequest((WindowEvent event) -> handleCloseRequest(scene, close_request_handler));
+        stage.setOnCloseRequest( ( WindowEvent event ) -> handleCloseRequest(scene, close_request_handler));
         stage.setAlwaysOnTop(true);
         stage.show();
 
         // If ScenicView.jar is added to classpath, open it here
-        //ScenicView.show(scene);
+        // ScenicView.show(scene);
 
         return getModelParent();
+
     }
 
     @Override


### PR DESCRIPTION
In a multi-screen situation, standalone window always open at (0,0), or at the location set in the Display widget itself, and this is annoying, requiring to do wide mouse movements to get the open window and move it on a reasonable position.

The change I've made save the location on close, and use it the next time the window is opened again.