### PR TITLE
CSSTUDIO-271: fixing random colours

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
@@ -29,8 +29,7 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.shape.StrokeType;
 import javafx.scene.transform.Rotate;
 import javafx.scene.transform.Translate;
-import se.europeanspallationsource.xaos.tools.svg.SVGContent;
-import se.europeanspallationsource.xaos.tools.svg.SVGLoader;
+import se.europeanspallationsource.xaos.components.SVG;
 
 /** Creates JavaFX item for model widget
  *  @author Megan Grodowitz
@@ -47,7 +46,7 @@ public class PictureRepresentation extends JFXBaseRepresentation<Group, PictureW
 
     private volatile Image img_loaded;
     private volatile ImageView iv;
-    private volatile SVGContent svg;
+    private volatile SVG svg;
     private volatile String img_path;
     private volatile double native_offset_x = 0.0;
     private volatile double native_offset_y = 0.0;
@@ -71,7 +70,7 @@ public class PictureRepresentation extends JFXBaseRepresentation<Group, PictureW
 
             if ( filename.toLowerCase().endsWith(".svg") ) {
 
-                final SVGContent svg = SVGLoader.load(ModelResourceUtil.openResourceStream(filename));
+                final SVG svg = SVG.load(ModelResourceUtil.openResourceStream(filename));
                 final Bounds bounds = svg.getLayoutBounds();
 
                 return new Dimension2D(bounds.getWidth(), bounds.getHeight());
@@ -167,7 +166,7 @@ public class PictureRepresentation extends JFXBaseRepresentation<Group, PictureW
                 try {
 
                     // Open the image from the stream created from the resource file
-                    svg = SVGLoader.load(ModelResourceUtil.openResourceStream(img_path));
+                    svg = SVG.load(ModelResourceUtil.openResourceStream(img_path));
 
                     Bounds bounds = svg.getLayoutBounds();
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -71,8 +71,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
-import se.europeanspallationsource.xaos.tools.svg.SVGContent;
-import se.europeanspallationsource.xaos.tools.svg.SVGLoader;
+import se.europeanspallationsource.xaos.components.SVG;
 
 
 /**
@@ -408,7 +407,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
                     finalSymbolHeight = (int) Math.floor(scale_fac * symbolHeight);
                 }
 
-                SVGContent svg = ic.getSVG();
+                SVG svg = ic.getSVG();
                 Bounds bounds = svg.getLayoutBounds();
                 double boundsWidth = bounds.getWidth();
                 double boundsHeight = bounds.getHeight();
@@ -833,7 +832,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
         private Image image;
         private double originalHeight;
         private double originalWidth;
-        private SVGContent svg;
+        private SVG svg;
 
         ImageContent ( String fileName ) {
 
@@ -845,7 +844,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
                     try {
 
                         // Open the image from the stream created from the resource file
-                        svg = SVGLoader.load(ModelResourceUtil.openResourceStream(imageFileName));
+                        svg = SVG.load(ModelResourceUtil.openResourceStream(imageFileName));
 
                         Bounds bounds = svg.getLayoutBounds();
 
@@ -909,7 +908,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
             return originalWidth;
         }
 
-        SVGContent getSVG() {
+        SVG getSVG() {
             return svg;
         }
 


### PR DESCRIPTION
Using the new XAOS ver. 0.2.7, whose main change is a fix in a shared styles cached used by the SVG loader that was now made per-loader instead of static.

SVGLoader was also removed, moving its only 3 static methods into SVGContent, now renamed just SVG.

**NOTE:** merge has to be done only after [maven-osgi-bundles#70](https://github.com/ControlSystemStudio/maven-osgi-bundles/pull/70).