### PR TITLE
CSSTUDIO-625: On opening, properties of the DisplayModel are not displayed.

### DIFF
--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/DisplayEditor.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/DisplayEditor.java
@@ -555,6 +555,16 @@ public class DisplayEditor
         {
             logger.log(Level.SEVERE, "Error representing model", ex);
         }
+
+        // Bring up the model's properties.
+        try
+        {
+            toolkit.execute(() -> selection.clear());
+        }
+        catch (final Exception ex)
+        {
+            logger.log(Level.SEVERE, "Error selecting model", ex);
+        }
     }
 
     /** @return Currently edited model */


### PR DESCRIPTION
Executing selection.clean() in the UI thread after the display model was set.