### PR TITLE
CSSTUDIO-590 ENTER not validating properties

### DIFF
--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -45,6 +45,7 @@ import org.csstudio.display.builder.representation.javafx.FilenameSupport;
 import org.csstudio.display.builder.util.ResourceUtil;
 import org.csstudio.display.builder.util.undo.UndoableActionManager;
 import org.csstudio.javafx.DialogHelper;
+import org.csstudio.javafx.InputUtils;
 import org.csstudio.javafx.MultiLineInputDialog;
 
 import javafx.event.ActionEvent;
@@ -452,7 +453,8 @@ public class PropertyPanelSection extends GridPane
         else if (property instanceof MacroizedWidgetProperty)
         {   // MacroizedWidgetProperty needs to be checked _after_ subclasses like PVNameWidgetProperty, FilenameWidgetProperty
             final MacroizedWidgetProperty<?> macro_prop = (MacroizedWidgetProperty<?>)property;
-            final TextField text = new TextField();
+            final TextField text = InputUtils.wrap(new TextField());
+
             text.setPromptText(macro_prop.getDefaultValue().toString());
             final MacroizedWidgetPropertyBinding binding = new MacroizedWidgetPropertyBinding(undo, text, macro_prop, other);
             bindings.add(binding);

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -241,7 +241,7 @@ public class PropertyPanelSection extends GridPane
         else if (property instanceof EnumWidgetProperty<?>)
         {
             final EnumWidgetProperty<?> enum_prop = (EnumWidgetProperty<?>) property;
-            final ComboBox<String> combo = new ComboBox<>();
+            final ComboBox<String> combo = InputUtils.wrap(new ComboBox<>());
             combo.setPromptText(property.getDefaultValue().toString());
             combo.getItems().addAll(enum_prop.getLabels());
             combo.setMaxWidth(Double.MAX_VALUE);
@@ -297,7 +297,7 @@ public class PropertyPanelSection extends GridPane
         else if (property instanceof BooleanWidgetProperty)
         {
             final BooleanWidgetProperty bool_prop = (BooleanWidgetProperty) property;
-            final ComboBox<String> combo = new ComboBox<>();
+            final ComboBox<String> combo = InputUtils.wrap(new ComboBox<>());
             combo.setPromptText(property.getDefaultValue().toString());
             combo.getItems().addAll("true", "false");
             combo.setMaxWidth(Double.MAX_VALUE);
@@ -355,7 +355,7 @@ public class PropertyPanelSection extends GridPane
         else if (property instanceof WidgetClassProperty)
         {
             final WidgetClassProperty widget_class_prop = (WidgetClassProperty) property;
-            final ComboBox<String> combo = new ComboBox<>();
+            final ComboBox<String> combo = InputUtils.wrap(new ComboBox<>());
             combo.setPromptText(property.getDefaultValue().toString());
             combo.setEditable(true);
             // List classes of this widget
@@ -371,7 +371,7 @@ public class PropertyPanelSection extends GridPane
         else if (property instanceof FilenameWidgetProperty)
         {
             final FilenameWidgetProperty file_prop = (FilenameWidgetProperty)property;
-            final TextField text = new TextField();
+            final TextField text = InputUtils.wrap(new TextField());
             text.setPromptText(file_prop.getDefaultValue().toString());
             text.setMaxWidth(Double.MAX_VALUE);
             final Button select_file = new Button("...");
@@ -403,7 +403,7 @@ public class PropertyPanelSection extends GridPane
         else if (property instanceof PVNameWidgetProperty)
         {
             final PVNameWidgetProperty pv_prop = (PVNameWidgetProperty)property;
-            final TextField text = new TextField();
+            final TextField text = InputUtils.wrap(new TextField());
             text.setPromptText(pv_prop.getDefaultValue().toString());
             final MacroizedWidgetPropertyBinding binding = new MacroizedWidgetPropertyBinding(undo, text, pv_prop, other)
             {

--- a/org.csstudio.javafx/src/org/csstudio/javafx/InputUtils.java
+++ b/org.csstudio.javafx/src/org/csstudio/javafx/InputUtils.java
@@ -1,0 +1,87 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * Copyright (C) 2016 European Spallation Source ERIC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.csstudio.javafx;
+
+import javafx.event.EventHandler;
+import javafx.event.EventTarget;
+import javafx.event.EventType;
+import javafx.scene.Node;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+
+/**
+ * ENTER and RETURN are handled differently, mostly when JavaFX is
+ * embedded in Eclipse RCP. This utility class provides a method to
+ * add a proper filter to a JavaFX {@link Node} to fix the problem.
+ *
+ * @author claudiorosati, European Spallation Source ERIC
+ * @version 1.0.0 1 Jun 2018
+ */
+public class InputUtils {
+
+    private InputUtils ( ) {
+    }
+
+    public static <T extends Node> T wrap ( T component ) {
+
+        component.addEventFilter(KeyEvent.ANY, new EnterHandler());
+
+        return component;
+
+    }
+
+    private static class EnterHandler implements EventHandler<KeyEvent> {
+
+        private KeyCode pressedCode = null;
+        private KeyCode typedCode = null;
+        private String character = null;
+
+        @Override
+        public void handle ( KeyEvent event ) {
+
+            EventType<KeyEvent> eventType = event.getEventType();
+
+            if ( eventType == KeyEvent.KEY_PRESSED ) {
+                pressedCode = event.getCode();
+                return;
+            } else if ( eventType == KeyEvent.KEY_TYPED ) {
+                typedCode = event.getCode();
+                character = event.getCharacter();
+                return;
+            } else if ( eventType == KeyEvent.KEY_RELEASED ) {
+
+                KeyCode releasedCode = event.getCode();
+
+                if ( releasedCode == KeyCode.UNDEFINED && typedCode == KeyCode.UNDEFINED && pressedCode == KeyCode.UNDEFINED && "\r".equals(character) ) {
+
+                    Object source = event.getSource();
+                    EventTarget target = event.getTarget();
+                    String txt = event.getText();
+                    boolean sDown = event.isShiftDown();
+                    boolean cDown = event.isControlDown();
+                    boolean aDown = event.isAltDown();
+                    boolean mDown = event.isMetaDown();
+
+                    ((Node) source).fireEvent(new KeyEvent(source, target, KeyEvent.KEY_PRESSED,  "\u0000",  txt, KeyCode.ENTER, sDown, cDown, aDown, mDown));
+                    ((Node) source).fireEvent(new KeyEvent(source, target, KeyEvent.KEY_TYPED,    character, txt, KeyCode.ENTER, sDown, cDown, aDown, mDown));
+                    ((Node) source).fireEvent(new KeyEvent(source, target, KeyEvent.KEY_RELEASED, "\u0000",  txt, KeyCode.ENTER, sDown, cDown, aDown, mDown));
+
+                }
+
+                pressedCode = null;
+                typedCode = null;
+                character = null;
+
+            }
+
+        }
+
+    }
+
+}

--- a/org.csstudio.javafx/src/org/csstudio/javafx/InputUtils.java
+++ b/org.csstudio.javafx/src/org/csstudio/javafx/InputUtils.java
@@ -19,6 +19,14 @@ import javafx.scene.input.KeyEvent;
  * ENTER and RETURN are handled differently, mostly when JavaFX is
  * embedded in Eclipse RCP. This utility class provides a method to
  * add a proper filter to a JavaFX {@link Node} to fix the problem.
+ * <p>
+ * On MacOS X with Java 8, when the application is run outside
+ * Eclipse RCP (i.e. pure JavaFX application), the inner handler
+ * will never fire new events, because ENTER and RETURN are considered
+ * equals. Instead, when the application is an Eclipse RCB-based one,
+ * then a proper {@link KeyCode#ENTER} is generated when the numpad
+ * ENTER key is pressed.
+ * </p>
  *
  * @author claudiorosati, European Spallation Source ERIC
  * @version 1.0.0 1 Jun 2018


### PR DESCRIPTION
This seems to be an Eclipse-RCP-related problem: while a pure JavaFX application treats RETURN and ENTER (numpad) keys identically, when JavaFX is embedded in Eclipse-RCP, ENTER doesn't work.

This has become a daily request by integrators at ESS, that use the numpad keyboard to enter values (positions, size, ...) and then press ENTER to validate them.

I've found what I think an elegant solution. I think I've wrapped all properties fields requiring RETURN to validate them. If not, as soon as someone will report it, it will be easy to fix.