### PR TITLE
CSSTUDIO-739: CTRL+click operations problematic on MacOS

### DIFF
--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/DisplayEditor.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/DisplayEditor.java
@@ -41,6 +41,7 @@ import org.csstudio.display.builder.representation.ToolkitListener;
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
 import org.csstudio.display.builder.util.ResourceUtil;
 import org.csstudio.display.builder.util.undo.UndoableActionManager;
+import org.csstudio.javafx.PlatformInfo;
 
 import javafx.application.Platform;
 import javafx.geometry.Point2D;
@@ -396,7 +397,7 @@ public class DisplayEditor
         {
             // Don't do that on control-click (to add/remove to current selection)
             // nor on right button (to open context menu)
-            if (event.isControlDown()   ||   ! event.isPrimaryButtonDown())
+            if ( ( PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown() ) || ! event.isPrimaryButtonDown())
                 return;
             logger.log(Level.FINE, "Mouse pressed in 'editor', de-select all widgets");
             event.consume();

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/DisplayEditor.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/DisplayEditor.java
@@ -41,7 +41,6 @@ import org.csstudio.display.builder.representation.ToolkitListener;
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
 import org.csstudio.display.builder.util.ResourceUtil;
 import org.csstudio.display.builder.util.undo.UndoableActionManager;
-import org.csstudio.javafx.PlatformInfo;
 
 import javafx.application.Platform;
 import javafx.geometry.Point2D;
@@ -397,7 +396,7 @@ public class DisplayEditor
         {
             // Don't do that on control-click (to add/remove to current selection)
             // nor on right button (to open context menu)
-            if ( ( PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown() ) || ! event.isPrimaryButtonDown())
+            if ( event.isShortcutDown() || ! event.isPrimaryButtonDown())
                 return;
             logger.log(Level.FINE, "Mouse pressed in 'editor', de-select all widgets");
             event.consume();

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/poly/PointsEditor.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/poly/PointsEditor.java
@@ -13,7 +13,6 @@ import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.properties.Points;
 import org.csstudio.display.builder.util.ResourceUtil;
-import org.csstudio.javafx.PlatformInfo;
 
 import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
@@ -254,7 +253,7 @@ public class PointsEditor
                 y_offset = getY()+SIZE/2 - event.getY();
                 getScene().setCursor(Cursor.CLOSED_HAND);
 
-                if (PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown())
+                if ( event.isShortcutDown() )
                 {
                     final double x, y;
                     if (index < points.size() - 1)
@@ -293,7 +292,7 @@ public class PointsEditor
             setOnMouseMoved(event ->
             {
                 event.consume();
-                if (( PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown() ) && cursor_add != null)
+                if ( event.isShortcutDown() && cursor_add != null)
                     getScene().setCursor(cursor_add);
                 else if ((event.isShiftDown() || event.isAltDown())  &&  cursor_remove != null)
                     getScene().setCursor(cursor_remove);

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/poly/PointsEditor.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/poly/PointsEditor.java
@@ -13,6 +13,7 @@ import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.properties.Points;
 import org.csstudio.display.builder.util.ResourceUtil;
+import org.csstudio.javafx.PlatformInfo;
 
 import javafx.collections.ObservableList;
 import javafx.event.EventHandler;
@@ -253,7 +254,7 @@ public class PointsEditor
                 y_offset = getY()+SIZE/2 - event.getY();
                 getScene().setCursor(Cursor.CLOSED_HAND);
 
-                if (event.isControlDown())
+                if (PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown())
                 {
                     final double x, y;
                     if (index < points.size() - 1)
@@ -292,7 +293,7 @@ public class PointsEditor
             setOnMouseMoved(event ->
             {
                 event.consume();
-                if (event.isControlDown()  &&  cursor_add != null)
+                if (( PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown() ) && cursor_add != null)
                     getScene().setCursor(cursor_add);
                 else if ((event.isShiftDown() || event.isAltDown())  &&  cursor_remove != null)
                     getScene().setCursor(cursor_remove);

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
@@ -37,6 +37,7 @@ import org.csstudio.display.builder.representation.javafx.AutocompleteMenu;
 import org.csstudio.display.builder.util.undo.CompoundUndoableAction;
 import org.csstudio.display.builder.util.undo.UndoableAction;
 import org.csstudio.display.builder.util.undo.UndoableActionManager;
+import org.csstudio.javafx.PlatformInfo;
 import org.csstudio.javafx.Tracker;
 
 import javafx.geometry.Point2D;
@@ -118,14 +119,14 @@ public class SelectedWidgetUITracker extends Tracker
         // Pass control-click down to underlying widgets
         addEventFilter(MouseEvent.MOUSE_PRESSED, event ->
         {
-            if (event.isControlDown())
+            if (PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown())
                 passClickToWidgets(event);
         });
 
         // Allow 'dragging' selected widgets
         setOnDragDetected(event ->
         {
-            if (! event.isControlDown())
+            if (! ( PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown() ))
                 return;
 
             logger.log(Level.FINE, "Starting to drag {0}", widgets);
@@ -357,7 +358,7 @@ public class SelectedWidgetUITracker extends Tracker
             if (GeometryTools.getDisplayBounds(widget).contains(event.getX(), event.getY()))
             {
                 logger.log(Level.FINE, "Tracker passes click through to {0}", widget);
-                toolkit.fireClick(widget, event.isControlDown());
+                toolkit.fireClick(widget, PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown());
             }
     }
 

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tracker/SelectedWidgetUITracker.java
@@ -37,7 +37,6 @@ import org.csstudio.display.builder.representation.javafx.AutocompleteMenu;
 import org.csstudio.display.builder.util.undo.CompoundUndoableAction;
 import org.csstudio.display.builder.util.undo.UndoableAction;
 import org.csstudio.display.builder.util.undo.UndoableActionManager;
-import org.csstudio.javafx.PlatformInfo;
 import org.csstudio.javafx.Tracker;
 
 import javafx.geometry.Point2D;
@@ -119,14 +118,14 @@ public class SelectedWidgetUITracker extends Tracker
         // Pass control-click down to underlying widgets
         addEventFilter(MouseEvent.MOUSE_PRESSED, event ->
         {
-            if (PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown())
+            if ( event.isShortcutDown() )
                 passClickToWidgets(event);
         });
 
         // Allow 'dragging' selected widgets
         setOnDragDetected(event ->
         {
-            if (! ( PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown() ))
+            if ( !event.isShortcutDown() )
                 return;
 
             logger.log(Level.FINE, "Starting to drag {0}", widgets);
@@ -358,7 +357,7 @@ public class SelectedWidgetUITracker extends Tracker
             if (GeometryTools.getDisplayBounds(widget).contains(event.getX(), event.getY()))
             {
                 logger.log(Level.FINE, "Tracker passes click through to {0}", widget);
-                toolkit.fireClick(widget, PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown());
+                toolkit.fireClick(widget, event.isShortcutDown());
             }
     }
 

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/util/Rubberband.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/util/Rubberband.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.csstudio.display.builder.editor.util;
 
+import org.csstudio.javafx.PlatformInfo;
+
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Group;
@@ -105,7 +107,7 @@ public class Rubberband
 
         handler.handleSelectedRegion(new Rectangle2D(Math.min(x0, x1), Math.min(y0, y1),
                                                      Math.abs(x1 - x0), Math.abs(y1 - y0)),
-                                     event.isControlDown());
+                                     PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown());
         event.consume();
     }
 }

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/util/Rubberband.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/util/Rubberband.java
@@ -7,8 +7,6 @@
  *******************************************************************************/
 package org.csstudio.display.builder.editor.util;
 
-import org.csstudio.javafx.PlatformInfo;
-
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Group;
@@ -107,7 +105,7 @@ public class Rubberband
 
         handler.handleSelectedRegion(new Rectangle2D(Math.min(x0, x1), Math.min(y0, y1),
                                                      Math.abs(x1 - x0), Math.abs(y1 - y0)),
-                                     PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown());
+                                     event.isShortcutDown());
         event.consume();
     }
 }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -119,6 +119,7 @@ import org.csstudio.display.builder.representation.javafx.widgets.WebBrowserRepr
 import org.csstudio.display.builder.representation.javafx.widgets.plots.ImageRepresentation;
 import org.csstudio.display.builder.representation.javafx.widgets.plots.XYPlotRepresentation;
 import org.csstudio.javafx.DialogHelper;
+import org.csstudio.javafx.PlatformInfo;
 import org.csstudio.javafx.Styles;
 import org.csstudio.javafx.rtplot.ColorMappingFunction;
 import org.csstudio.javafx.rtplot.NamedColorMapping;
@@ -428,7 +429,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         if (isEditMode())
             model_root.addEventFilter(ScrollEvent.ANY, evt ->
             {
-                if (evt.isControlDown())
+                if (PlatformInfo.is_mac_os_x ? evt.isShortcutDown() : evt.isControlDown())
                 {
                     evt.consume();
                     doWheelZoom(evt.getDeltaY(), evt.getX(), evt.getY());
@@ -437,7 +438,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         else
             widget_parent.addEventHandler(ScrollEvent.ANY, evt ->
             {
-                if (evt.isControlDown())
+                if (PlatformInfo.is_mac_os_x ? evt.isShortcutDown() : evt.isControlDown())
                 {
                     evt.consume();
                     ScrollEvent gevt = evt.copyFor(model_root, scroll_body);

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/JFXRepresentation.java
@@ -119,7 +119,6 @@ import org.csstudio.display.builder.representation.javafx.widgets.WebBrowserRepr
 import org.csstudio.display.builder.representation.javafx.widgets.plots.ImageRepresentation;
 import org.csstudio.display.builder.representation.javafx.widgets.plots.XYPlotRepresentation;
 import org.csstudio.javafx.DialogHelper;
-import org.csstudio.javafx.PlatformInfo;
 import org.csstudio.javafx.Styles;
 import org.csstudio.javafx.rtplot.ColorMappingFunction;
 import org.csstudio.javafx.rtplot.NamedColorMapping;
@@ -429,7 +428,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         if (isEditMode())
             model_root.addEventFilter(ScrollEvent.ANY, evt ->
             {
-                if (PlatformInfo.is_mac_os_x ? evt.isShortcutDown() : evt.isControlDown())
+                if ( evt.isShortcutDown() )
                 {
                     evt.consume();
                     doWheelZoom(evt.getDeltaY(), evt.getX(), evt.getY());
@@ -438,7 +437,7 @@ public class JFXRepresentation extends ToolkitRepresentation<Parent, Node>
         else
             widget_parent.addEventHandler(ScrollEvent.ANY, evt ->
             {
-                if (PlatformInfo.is_mac_os_x ? evt.isShortcutDown() : evt.isControlDown())
+                if (  evt.isShortcutDown() )
                 {
                     evt.consume();
                     ScrollEvent gevt = evt.copyFor(model_root, scroll_body);

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
@@ -21,6 +21,7 @@ import org.csstudio.display.builder.model.widgets.TabsWidget;
 import org.csstudio.display.builder.model.widgets.TabsWidget.TabItemProperty;
 import org.csstudio.display.builder.representation.WidgetRepresentation;
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
+import org.csstudio.javafx.PlatformInfo;
 
 import javafx.event.EventHandler;
 import javafx.scene.Node;
@@ -90,7 +91,7 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
                     if (event.isPrimaryButtonDown())
                     {
                         event.consume();
-                        toolkit.fireClick(model_widget, event.isControlDown());
+                        toolkit.fireClick(model_widget, PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown());
                     }
                 };
                 if (isFilteringEditModeClicks())

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
@@ -21,7 +21,6 @@ import org.csstudio.display.builder.model.widgets.TabsWidget;
 import org.csstudio.display.builder.model.widgets.TabsWidget.TabItemProperty;
 import org.csstudio.display.builder.representation.WidgetRepresentation;
 import org.csstudio.display.builder.representation.javafx.JFXRepresentation;
-import org.csstudio.javafx.PlatformInfo;
 
 import javafx.event.EventHandler;
 import javafx.scene.Node;
@@ -91,7 +90,7 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
                     if (event.isPrimaryButtonDown())
                     {
                         event.consume();
-                        toolkit.fireClick(model_widget, PlatformInfo.is_mac_os_x ? event.isShortcutDown() : event.isControlDown());
+                        toolkit.fireClick(model_widget, event.isShortcutDown());
                     }
                 };
                 if (isFilteringEditModeClicks())


### PR DESCRIPTION
Zoom, extending selection with click or rubberbanding, adding points to polyline now working with COMMAND instead of CTRL on MacOS.