### PR TITLE
CSSTUDIO-736: lasso selection

### DIFF
--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/util/GeometryTools.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/util/GeometryTools.java
@@ -189,13 +189,15 @@ public class GeometryTools
             final List<Widget> found = new ArrayList<>();
             for (final Widget widget : widgets)
             {
-                if (region.contains(getDisplayBounds(widget)))
+                if (region.contains(getDisplayBounds(widget))) {
                     found.add(widget);
-                final ChildrenProperty children = ChildrenProperty.getChildren(widget);
-                if (children != null)
-                {
-                    final WidgetSearch sub = new WidgetSearch(children.getValue(), region);
-                    found.addAll(sub.compute());
+                } else {
+                    final ChildrenProperty children = ChildrenProperty.getChildren(widget);
+                    if (children != null)
+                    {
+                        final WidgetSearch sub = new WidgetSearch(children.getValue(), region);
+                        found.addAll(sub.compute());
+                    }
                 }
             }
             return found;


### PR DESCRIPTION
There is a problem in the previous implementation of lasso selection: if a group is selected, then the group AND its content is selected. If you then move the selection, everything seems going crazy, because the same offset is applied to the group and the its content, which has a different coordinate system. Even worse, because of #403 you cannot undo the operation.

In this PR, children are selected only if their container is not selected. So lassoing around a group select only the group, lassoing around its content only (starting from outside) will select the content.

My integrators raising the problem, tested and like it. Moreover, with CTRL/CMD (see #402) you can easily add to the selection something from the contents if needed.