### PR TITLE
CSSTUDIO-778: Add flat property to LEDs.

### DIFF
--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/Messages.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/Messages.java
@@ -194,6 +194,7 @@ public class Messages extends NLS
     public static String WidgetProperties_ExtremaVisible;
     public static String WidgetProperties_File;
     public static String WidgetProperties_FillColor;
+    public static String WidgetProperties_Flat;
     public static String WidgetProperties_FlatBar;
     public static String WidgetProperties_Font;
     public static String WidgetProperties_ForegroundColor;

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/messages.properties
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/messages.properties
@@ -176,6 +176,7 @@ WidgetProperties_ExtremaVisible=Extrema Visible
 WidgetProperties_DragDisabled=Drag Disabled
 WidgetProperties_File=File
 WidgetProperties_FillColor=Fill Color
+WidgetProperties_Flat=Flat LED
 WidgetProperties_FlatBar=Flat Bar
 WidgetProperties_Font=Font
 WidgetProperties_ForegroundColor=Foreground Color

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/properties/CommonWidgetProperties.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/properties/CommonWidgetProperties.java
@@ -535,6 +535,10 @@ public class CommonWidgetProperties
     public static final WidgetPropertyDescriptor<Boolean> propWrapWords =
             newBooleanPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "wrap_words", Messages.WidgetProperties_WrapWords);
 
+    /** Flat or shaded LED? */
+    public static final WidgetPropertyDescriptor<Boolean> propFlat =
+            newBooleanPropertyDescriptor(WidgetPropertyCategory.DISPLAY, "flat", Messages.WidgetProperties_Flat);
+
     /** Property for the 'off' color */
     public static final WidgetPropertyDescriptor<WidgetColor> propOffColor = new WidgetPropertyDescriptor<WidgetColor>(
             WidgetPropertyCategory.DISPLAY, "off_color", Messages.WidgetProperties_OffColor)

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/BaseLEDWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/BaseLEDWidget.java
@@ -65,6 +65,7 @@ public class BaseLEDWidget extends PVWidget
     protected volatile WidgetProperty<WidgetFont> font;
     protected volatile WidgetProperty<WidgetColor> foreground;
     protected volatile WidgetProperty<Boolean> square;
+    protected volatile WidgetProperty<Boolean> flat;
 
     /** Widget constructor.
      *  @param type Widget type
@@ -101,5 +102,11 @@ public class BaseLEDWidget extends PVWidget
     public WidgetProperty<Boolean> propSquare()
     {
         return square;
+    }
+
+    /** @return 'flat' property*/
+    public WidgetProperty<Boolean> propFlat()
+    {
+        return flat;
     }
 }

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/BoolButtonWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/BoolButtonWidget.java
@@ -14,6 +14,7 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propConfirmDialogOptions;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propConfirmMessage;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propEnabled;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFlat;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFont;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLabelsFromPV;
@@ -121,6 +122,7 @@ public class BoolButtonWidget extends WritablePVWidget
     private volatile WidgetProperty<ConfirmDialog> confirm_dialog;
     private volatile WidgetProperty<String> confirm_message;
     private volatile WidgetProperty<String> password;
+    private volatile WidgetProperty<Boolean> flat;
 
     public BoolButtonWidget()
     {
@@ -146,6 +148,7 @@ public class BoolButtonWidget extends WritablePVWidget
         properties.add(on_color = propOnColor.createProperty(this, new WidgetColor(60, 255, 60)));
         properties.add(on_image = propOnImage.createProperty(this, ""));
         properties.add(show_LED = propShowLED.createProperty(this, true));
+        properties.add(flat = propFlat.createProperty(this, false));
         properties.add(font = propFont.createProperty(this, WidgetFontService.get(NamedWidgetFonts.DEFAULT)));
         properties.add(foreground = propForegroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.TEXT)));
         properties.add(background = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BUTTON_BACKGROUND)));
@@ -250,5 +253,11 @@ public class BoolButtonWidget extends WritablePVWidget
     public WidgetProperty<String> propPassword()
     {
         return password;
+    }
+
+    /** @return 'flat' property*/
+    public WidgetProperty<Boolean> propFlat()
+    {
+        return flat;
     }
 }

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/ByteMonitorWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/ByteMonitorWidget.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.model.widgets;
 
 import static  org.csstudio.display.builder.model.properties.CommonWidgetProperties.newBooleanPropertyDescriptor;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFlat;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propHorizontal;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propOffColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propOnColor;
@@ -108,6 +109,7 @@ public class ByteMonitorWidget extends PVWidget
     private volatile WidgetProperty<Boolean> bitReverse;
     private volatile WidgetProperty<Boolean> horizontal;
     private volatile WidgetProperty<Boolean> square;
+    private volatile WidgetProperty<Boolean> flat;
 
     public ByteMonitorWidget()
     {
@@ -123,6 +125,7 @@ public class ByteMonitorWidget extends PVWidget
         properties.add(bitReverse = propBitReverse.createProperty(this,false));
         properties.add(horizontal = propHorizontal.createProperty(this,true));
         properties.add(square = propSquare.createProperty(this,false));
+        properties.add(flat = propFlat.createProperty(this, false));
         properties.add(off_color = propOffColor.createProperty(this, new WidgetColor(60, 100, 60)));
         properties.add(on_color = propOnColor.createProperty(this, new WidgetColor(60, 255, 60)));
     }
@@ -174,5 +177,11 @@ public class ByteMonitorWidget extends PVWidget
     public WidgetProperty<Boolean> propSquare()
     {
         return square;
+    }
+
+    /** @return 'flat' property*/
+    public WidgetProperty<Boolean> propFlat()
+    {
+        return flat;
     }
 }

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/LEDWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/LEDWidget.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.model.widgets;
 
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBit;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFlat;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFont;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propLabelsFromPV;
@@ -115,6 +116,7 @@ public class LEDWidget extends BaseLEDWidget
         properties.add(font = propFont.createProperty(this, WidgetFontService.get(NamedWidgetFonts.DEFAULT)));
         properties.add(foreground = propForegroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.TEXT)));
         properties.add(square = propSquare.createProperty(this, false));
+        properties.add(flat = propFlat.createProperty(this, false));
         // Ideally, widgets should fetch their information from a PV,
         // but the LED does not allow much room for text,
         // so the default text from the PV is likely too large..

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/MultiStateLEDWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/MultiStateLEDWidget.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.csstudio.display.builder.model.widgets;
 
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFlat;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFont;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propSquare;
@@ -193,6 +194,7 @@ public class MultiStateLEDWidget extends BaseLEDWidget
         properties.add(font = propFont.createProperty(this, WidgetFontService.get(NamedWidgetFonts.DEFAULT)));
         properties.add(foreground = propForegroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.TEXT)));
         properties.add(square = propSquare.createProperty(this, false));
+        properties.add(flat = propFlat.createProperty(this, false));
     }
 
     /** @return 'states' property */

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
@@ -4,9 +4,15 @@
 /* LEDRepresentation */
 .led
 {
-    -fx-stroke-width: 2;
+    -fx-stroke-width: 2.11;
     -fx-stroke-type: inside;
-    -fx-stroke: linear-gradient(to bottom right, #808080, #f0f0f0);
+    -fx-stroke: linear-gradient(to bottom right, #6E6F6E, #E7E6E5);
+}
+.led_flat
+{
+    -fx-stroke-width: 2.44;
+    -fx-stroke-type: inside;
+    -fx-stroke: rgba(0, 0, 0, 0.7);
 }
 .led_label
 {

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -19,7 +19,8 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.CycleMethod;
-import javafx.scene.paint.RadialGradient;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Paint;
 import javafx.scene.paint.Stop;
 import javafx.scene.shape.Ellipse;
 import javafx.scene.shape.Rectangle;
@@ -31,6 +32,39 @@ import javafx.scene.shape.Shape;
 @SuppressWarnings("nls")
 abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBaseRepresentation<Pane, LED>
 {
+
+    public static Paint makeLEDGradient ( Color color ) {
+
+        //  Original BaseLEDRepresentation & BoolButtonRepresentation gradient
+        //      put highlight in top-left corner, about 0.2 wide,
+        //      relative to actual size of LED
+//        return new RadialGradient(
+//            0, 0,
+//            0.3, 0.3, 0.4,
+//            true, CycleMethod.NO_CYCLE,
+//            new Stop(0, color.interpolate(Color.WHITESMOKE, 0.8)),
+//            new Stop(1, color)
+//        );
+
+        // Original ByteMonitorRepresentation gradient
+//        return new LinearGradient(
+//            0, 0,
+//            .7, .7,
+//            true, CycleMethod.NO_CYCLE,
+//            new Stop(0, color.interpolate(Color.WHITESMOKE, 0.8)),
+//            new Stop(1, color)
+//        );
+
+        return new LinearGradient(
+            0, 0,
+            .6, .6,
+            true, CycleMethod.NO_CYCLE,
+            new Stop(0, color.interpolate(Color.WHITESMOKE, 0.777)),
+            new Stop(1, color)
+        );
+
+    }
+
     private final DirtyFlag typeChanged = new DirtyFlag();
     private final DirtyFlag styleChanged = new DirtyFlag();
     protected final DirtyFlag dirty_content = new DirtyFlag();
@@ -62,7 +96,7 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
             led = new Rectangle();
         else
             led = new Ellipse();
-        led.getStyleClass().add("led");
+        led.getStyleClass().add(model_widget.propFlat().getValue() ? "led_flat" : "led");
         label = new Label();
         label.getStyleClass().add("led_label");
         label.setAlignment(Pos.CENTER);
@@ -103,6 +137,7 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
     {
         super.registerListeners();
         model_widget.propSquare().addPropertyListener(this::typeChanged);
+        model_widget.propFlat().addPropertyListener(this::typeChanged);
         model_widget.propWidth().addUntypedPropertyListener(this::styleChanged);
         model_widget.propHeight().addUntypedPropertyListener(this::styleChanged);
         model_widget.propFont().addUntypedPropertyListener(this::styleChanged);
@@ -199,13 +234,9 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
         }
         if (dirty_content.checkAndClear())
         {
-            led.setFill(
-                // Put highlight in top-left corner, about 0.2 wide,
-                // relative to actual size of LED
-                new RadialGradient(0, 0, 0.3, 0.3, 0.4, true, CycleMethod.NO_CYCLE,
-                                   new Stop(0, value_color.interpolate(Color.WHITESMOKE, 0.8)),
-                                   new Stop(1, value_color)));
+            led.setFill(model_widget.propFlat().getValue() ? value_color : makeLEDGradient(value_color));
             label.setText(value_label);
         }
     }
+
 }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.representation.javafx.widgets;
 
 import static org.csstudio.display.builder.representation.ToolkitRepresentation.logger;
+import static org.csstudio.display.builder.representation.javafx.widgets.BaseLEDRepresentation.makeLEDGradient;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -29,9 +30,6 @@ import javafx.scene.control.ButtonBase;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.paint.Color;
-import javafx.scene.paint.CycleMethod;
-import javafx.scene.paint.RadialGradient;
-import javafx.scene.paint.Stop;
 import javafx.scene.shape.Ellipse;
 
 /** Creates JavaFX item for model widget
@@ -76,6 +74,7 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
     public ButtonBase createJFXNode() throws Exception
     {
         led = new Ellipse();
+        led.getStyleClass().add(model_widget.propFlat().getValue() ? "led_flat" : "led");
         button = new Button("BoolButton", led);
         button.getStyleClass().add("action_button");
         button.setOnAction(event -> handlePress());
@@ -144,6 +143,7 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
         model_widget.propOnImage().addUntypedPropertyListener(this::imagesChanged);
         model_widget.propOnColor().addUntypedPropertyListener(this::representationChanged);
         model_widget.propShowLED().addUntypedPropertyListener(this::representationChanged);
+        model_widget.propFlat().addUntypedPropertyListener(this::representationChanged);
         model_widget.propFont().addUntypedPropertyListener(this::representationChanged);
         model_widget.propForegroundColor().addUntypedPropertyListener(this::representationChanged);
         model_widget.propBackgroundColor().addUntypedPropertyListener(this::representationChanged);
@@ -261,6 +261,9 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
                 final int size = Math.min(wid, hei);
                 led.setRadiusX(size / 3.7);
                 led.setRadiusY(size / 3.7);
+                led.getStyleClass().remove("led_flat");
+                led.getStyleClass().remove("led");
+                led.getStyleClass().add(model_widget.propFlat().getValue() ? "led_flat" : "led");
             }
             else
             {
@@ -285,11 +288,7 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
             if (image == null)
             {
                 jfx_node.setGraphic(led);
-                // Put highlight in top-left corner, about 0.2 wide,
-                // relative to actual size of LED
-                led.setFill(new RadialGradient(0, 0, 0.3, 0.3, 0.4, true, CycleMethod.NO_CYCLE,
-                        new Stop(0, value_color.interpolate(Color.WHITESMOKE, 0.8)),
-                        new Stop(1, value_color)));
+                led.setFill(model_widget.propFlat().getValue() ? value_color : makeLEDGradient(value_color));
             }
             else
                 jfx_node.setGraphic(image);


### PR DESCRIPTION
- Refactored the code that creates the LED gradient in order to have the same shading effect.
- Added border to LED in BooleanButton, making the LED "going inside the button".
- Added "flat" property to have more modern L&F for LEDs.
- Small tweaks in the led CSS style.

Here the new appearance on white and very dark gray background:

![f1](https://user-images.githubusercontent.com/10833922/43719078-f0e95c9a-998c-11e8-8a55-701fb637ff95.png)

Here with the ESS background and group background:

![f2](https://user-images.githubusercontent.com/10833922/43719089-fdf02d60-998c-11e8-9182-87b2c01edd44.png)
