### PR TITLE
Improved LED border visibility.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
@@ -4,7 +4,7 @@
 /* LEDRepresentation */
 .led
 {
-    -fx-stroke-width: 2;
+    -fx-stroke-width: 2.345;
     -fx-stroke-type: inside;
     -fx-stroke: rgba(50, 50, 50, 0.7);
 }


### PR DESCRIPTION
The previous 3D border contributed to the colour desaturation produced by the LED bulb shading. At the same time, the 2 pixels thick etched border was more distinguishable than the flat border at the same thickness. For this reason I've increased the thickness  of a it more than half pixel.

Before:

<img width="674" alt="f1" src="https://user-images.githubusercontent.com/10833922/43761383-3b57c896-9a25-11e8-82fa-6962f483ed87.png">

After:

<img width="675" alt="f2" src="https://user-images.githubusercontent.com/10833922/43761394-41647f68-9a25-11e8-8e38-26a86451217a.png">
