### PR TITLE
CSSTUDIO-785 Single-image Symbol widget doesn't save the image file id create via ALD+D&D.

### DIFF
--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/util/WidgetTransfer.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/util/WidgetTransfer.java
@@ -38,12 +38,10 @@ import org.csstudio.display.builder.editor.EditorUtil;
 import org.csstudio.display.builder.editor.Messages;
 import org.csstudio.display.builder.editor.palette.Palette;
 import org.csstudio.display.builder.editor.tracker.SelectedWidgetUITracker;
-import org.csstudio.display.builder.model.ArrayWidgetProperty;
 import org.csstudio.display.builder.model.DisplayModel;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetFactory;
-import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.persist.ModelReader;
 import org.csstudio.display.builder.model.persist.ModelWriter;
 import org.csstudio.display.builder.model.persist.WidgetClassesService;
@@ -497,14 +495,9 @@ public class WidgetTransfer {
 
         final DisplayModel model = selection_tracker.getModel();
         final SymbolWidget widget = (SymbolWidget) SymbolWidget.WIDGET_DESCRIPTOR.createWidget();
-        ArrayWidgetProperty<WidgetProperty<String>> propSymbols = widget.propSymbols();
 
         for ( int i = 0; i < fileNames.size(); i++ ) {
-            if ( i < propSymbols.size() ) {
-                propSymbols.getElement(i).setValue(fileNames.get(i));
-            } else {
-                widget.addSymbol(fileNames.get(i));
-            }
+            widget.addOrReplaceSymbol(i, fileNames.get(i));
         }
 
         final int index = widgets.size();

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -547,7 +547,10 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
         model_widget.propPVName().addPropertyListener(this::contentChanged);
 
         model_widget.propSymbols().addPropertyListener(this::imagesChanged);
-        model_widget.propSymbols().getValue().stream().forEach(p -> p.addPropertyListener(imagePropertyListener));
+        model_widget.propSymbols().getValue().stream().forEach(p -> {
+            p.removePropertyListener(imagePropertyListener);
+            p.addPropertyListener(imagePropertyListener);
+        });
 
         model_widget.propInitialIndex().addPropertyListener(this::initialIndexChanged);
 
@@ -751,13 +754,8 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
                     return;
             }
 
-
             for ( int i = 0; i < fileNames.size(); i++ ) {
-                if ( i < propSymbols.size() ) {
-                    propSymbols.getElement(i).setValue(fileNames.get(i));
-                } else {
-                    model_widget.addSymbol(fileNames.get(i));
-                }
+                model_widget.addOrReplaceSymbol(i, fileNames.get(i));
             }
 
         } finally {
@@ -826,10 +824,9 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
 
                     ImageContent imageContent = imagesList.get(getImageIndex());
 
-                    if ( ( imageContent.isSVG() && imagePane.getCenter() == imageView )
-                      || ( imageContent.isImage() && imagePane.getCenter() != imageView ) ) {
+                    if ( imageContent.isSVG() || ( imageContent.isImage() && imagePane.getCenter() != imageView ) ) {
                         Platform.runLater(() -> triggerContentUpdate());
-                    } else if ( imageContent.isImage() && getDefaultSymbol().equals(imageView.getImage()) ) {
+                    } else if ( imageContent.isImage() ) {
                         Platform.runLater(() -> triggerImageUpdate());
                     }
 


### PR DESCRIPTION
- Symbols property was not properly initialised.
- Fixed also symbol not updated if corresponding file was changed.
- A bit of refactoring.