### PR TITLE
Catching an NPE blocking DataBrowser AND DisplayBuilder to start.

### DIFF
--- a/databrowser3/databrowser-plugins/org.csstudio.trends.databrowser3/src/org/csstudio/trends/databrowser3/Activator.java
+++ b/databrowser3/databrowser-plugins/org.csstudio.trends.databrowser3/src/org/csstudio/trends/databrowser3/Activator.java
@@ -75,12 +75,16 @@ public class Activator extends AbstractUIPlugin
     {
         super.start(context);
 
-        // Determine width of widest monitor
-        for (Monitor monitor : Display.getCurrent().getMonitors())
-        {
-            final int wid = monitor.getBounds().width;
-            if (wid > display_pixel_width)
-                display_pixel_width = wid;
+        try {
+            // Determine width of widest monitor
+            for (Monitor monitor : Display.getCurrent().getMonitors())
+            {
+                final int wid = monitor.getBounds().width;
+                if (wid > display_pixel_width)
+                    display_pixel_width = wid;
+            }
+        } catch ( Exception ex ) {
+            logger.log(Level.WARNING, "Errors determining display pixel width.", ex);
         }
         if (display_pixel_width <= 0)
         {


### PR DESCRIPTION
Added try-catch block to catch an NPE blocking DataBrowser AND DisplayBuilder widgets to be loaded.

@kasemir 
All my last 3 PR are important to ESS, but this one is really blocking.
The `for (Monitor monitor : Display.getCurrent().getMonitors())` is generating the NPE that, no only prevents the DataBrowser plugin to be loaded, but then also the Display Builder to load widgets.
Is it possible that the DataBrowser plugin is activated before `Display.getCurrent()` has a valid value?