### PR TITLE
Width and height swapped when horizontal is changed.

### DIFF
--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/ByteMonitorWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/ByteMonitorWidget.java
@@ -117,7 +117,9 @@ public class ByteMonitorWidget extends PVWidget
     @Override
     protected void defineProperties(final List<WidgetProperty<?>> properties)
     {
+
         super.defineProperties(properties);
+
         properties.add(startBit = propStartBit.createProperty(this,0));
         properties.add(numBits = propNumBits.createProperty(this,8));
         properties.add(bitReverse = propBitReverse.createProperty(this,false));
@@ -125,6 +127,17 @@ public class ByteMonitorWidget extends PVWidget
         properties.add(square = propSquare.createProperty(this,false));
         properties.add(off_color = propOffColor.createProperty(this, new WidgetColor(60, 100, 60)));
         properties.add(on_color = propOnColor.createProperty(this, new WidgetColor(60, 255, 60)));
+
+        horizontal.addPropertyListener(( p, o, n ) -> {
+
+            final int w = propWidth().getValue();
+            final int h = propHeight().getValue();
+
+            propWidth().setValue(h);
+            propHeight().setValue(w);
+
+        });
+
     }
 
     @Override


### PR DESCRIPTION
This PR addressed what happens when `horizontal` is changed in ByteMonitor widget, moving from this situation

<img width="234" alt="f1" src="https://user-images.githubusercontent.com/10833922/44388285-08d12800-a528-11e8-8ae1-192293686f7b.png">

to the following one

<img width="214" alt="f2" src="https://user-images.githubusercontent.com/10833922/44388296-11296300-a528-11e8-9276-eec40daee8ae.png">

The change happens in the model, because I don't think it is a representation business.