### PR TITLE
Added test suite to execute tests in the right order.

### DIFF
--- a/org.csstudio.display.builder.runtime.test/pom.xml
+++ b/org.csstudio.display.builder.runtime.test/pom.xml
@@ -1,13 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.csstudio</groupId>
-    <artifactId>display-builder</artifactId>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.csstudio</groupId>
+        <artifactId>display-builder</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>org.csstudio.display.builder.runtime.test</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-  </parent>
-  <artifactId>org.csstudio.display.builder.runtime.test</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
-  <packaging>eclipse-test-plugin</packaging>
+    <packaging>eclipse-test-plugin</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>1.1.0</version>
+                <configuration>
+                    <testClass>org.csstudio.display.builder.runtime.test.RuntimeTestsSuite</testClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/org.csstudio.display.builder.runtime.test/src/org/csstudio/display/builder/runtime/test/RuntimeTestsSuite.java
+++ b/org.csstudio.display.builder.runtime.test/src/org/csstudio/display/builder/runtime/test/RuntimeTestsSuite.java
@@ -1,0 +1,40 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * Copyright (C) 2016 European Spallation Source ERIC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.csstudio.display.builder.runtime.test;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.python.core.PySystemState;
+
+/**
+ * This suite was necessary to impose {@link JythonTest} being executed
+ * before {@link JythonScriptTest}, otherwise the {@link PySystemState}
+ * will be already initialized.
+ *
+ * @author claudiorosati, European Spallation Source ERIC
+ * @version 1.0.0 27 Sep 2018
+ */
+@RunWith( Suite.class )
+@Suite.SuiteClasses( {
+    //  Keep the following classes in this specifi order.
+    JythonTest.class,
+    JythonScriptTest.class,
+    RulesJythonScriptTest.class,
+    //  The following classes can be in any order.
+    ArrayPVDispatcherTest.class,
+    CommandExecutorTest.class,
+    PVFactoryTest.class,
+    PythonGatewaySupportTest.class,
+    PythonScriptTest.class,
+    TextPatchTest.class,
+} )
+@SuppressWarnings( { "ClassMayBeInterface", "ClassWithoutLogger" } )
+public class RuntimeTestsSuite {
+
+}


### PR DESCRIPTION
This PR closes #448.

Note that for CS-Studio the following was added to the `pom.xml`

```xml
    <build>
        <plugins>
            <plugin>
                <groupId>org.eclipse.tycho</groupId>
                <artifactId>tycho-surefire-plugin</artifactId>
                <version>1.1.0</version>
                <configuration>
                    <testClass>org.csstudio.display.builder.runtime.test.RuntimeTestsSuite</testClass>
                </configuration>
            </plugin>
        </plugins>
    </build>
```

For Phoebus the following should be added instead:

```xml
    <build>
        <plugins>
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
                <version>2.22.0</version>
                <configuration>
                    <includes>
                        <include>**/*Suite.java</include>
                    </includes>
                </configuration>
            </plugin>
        </plugins>
    </build>
```