### PR TITLE
CSSTUDIO-836 symbol widget

### DIFF
--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/SymbolWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/SymbolWidget.java
@@ -172,7 +172,7 @@ public class SymbolWidget extends PVWidget {
 
         super.defineProperties(properties);
 
-        properties.add(symbols        = propSymbols.createProperty(this, Collections.singletonList(propSymbol(0).createProperty(this, "platform:/plugin/org.csstudio.display.builder.model/icons/default_symbol.png"))));
+        properties.add(symbols        = propSymbols.createProperty(this, Collections.emptyList()));
 
         properties.add(background     = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
         properties.add(initial_index  = propInitialIndex.createProperty(this, 0));
@@ -206,7 +206,6 @@ public class SymbolWidget extends PVWidget {
             if ( xml_version.getMajor() < 2 ) {
 
                 SymbolWidget symbol = (SymbolWidget) widget;
-                ArrayWidgetProperty<WidgetProperty<String>> propSymbols = symbol.propSymbols();
                 List<String> fileNames = new ArrayList<>(2);
 
                 symbol.importedFrom = xml.getAttribute("typeId");

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/SymbolWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/SymbolWidget.java
@@ -172,7 +172,7 @@ public class SymbolWidget extends PVWidget {
 
         super.defineProperties(properties);
 
-        properties.add(symbols        = propSymbols.createProperty(this, Collections.emptyList()));
+        properties.add(symbols        = propSymbols.createProperty(this, Collections.singletonList(propSymbol(0).createProperty(this, "platform:/plugin/org.csstudio.display.builder.model/icons/default_symbol.png"))));
 
         properties.add(background     = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
         properties.add(initial_index  = propInitialIndex.createProperty(this, 0));

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -130,7 +130,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
 
         toolkit.execute(() -> {
             this.imageIndex.set(imageIndex);
-            jfx_node.getChildren().set(0, symbol.getNode());
+            jfx_node.getChildren().set(0, getSymbolNode());
         });
 
     }
@@ -303,7 +303,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
             }
 
             if ( symbol != null ) {
-                symbol.setSize(w, h, model_widget.propPreserveRatio().getValue());
+                setSymbolSize(w, h, model_widget.propPreserveRatio().getValue());
             }
 
             jfx_node.setLayoutX(model_widget.propX().getValue());
@@ -364,7 +364,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
         indexLabel.setVisible(model_widget.propShowIndex().getValue());
         indexLabel.textProperty().bind(Bindings.convert(imageIndexProperty()));
 
-        symbolPane.getChildren().addAll(symbol.getNode(), indexLabelBackground, indexLabel);
+        symbolPane.getChildren().addAll(getSymbolNode(), indexLabelBackground, indexLabel);
 
         if ( model_widget.propTransparent().getValue() ) {
             symbolPane.setBackground(null);
@@ -516,9 +516,37 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
         return defaultSymbolNode;
     }
 
+    Node getSymbolNode ( ) {
+
+        Image image = symbol.getImage();
+
+        if ( image == null ) {
+            return getDefaultSymbolNode();
+        } else {
+
+            imageView.setImage(image);
+
+            return imageView;
+
+        }
+
+    }
+
     private void initialIndexChanged ( final WidgetProperty<?> property, final Object oldValue, final Object newValue ) {
         dirtyValue.mark();
         toolkit.scheduleUpdate(this);
+    }
+
+    void setSymbolSize ( double width, double height, boolean preserveRatio ) {
+        if ( symbol != null ) {
+            if ( symbol.getImage() == null ) {
+                getDefaultSymbolNode().setSize(width, height);
+            } else {
+                imageView.setFitWidth(width);
+                imageView.setFitHeight(height);
+                imageView.setPreserveRatio(preserveRatio);
+            }
+        }
     }
 
     private void styleChanged ( final WidgetProperty<?> property, final Object oldValue, final Object newValue ) {
@@ -666,27 +694,17 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
 
         private final String fileName;
         private Image image = null;
-        private DefaultSymbolNode defaultNode = null;
-        private double originalHeight;
-        private double originalWidth;
+        private double originalHeight = 100;
+        private double originalWidth = 100;
 
         Symbol ( ) {
-
             fileName = null;
-            defaultNode = getDefaultSymbolNode();
-
-            Bounds bounds = defaultNode.getLayoutBounds();
-
-            originalWidth = bounds.getWidth();
-            originalHeight = bounds.getHeight();
-
         }
 
         Symbol ( String fileName ) {
 
             this.fileName = fileName;
 
-            boolean loadFailed = true;
             String imageFileName = resolveImageFile(model_widget, fileName);
 
             if ( imageFileName != null ) {
@@ -696,8 +714,9 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
                 if ( image != null ) {
                     originalWidth = image.getWidth();
                     originalHeight = image.getHeight();
-                    loadFailed = false;
                 } else {
+
+                    boolean loadFailed = true;
 
                     if ( imageFileName.toLowerCase().endsWith(".svg") ) {
                         try {
@@ -746,17 +765,6 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
                 }
             }
 
-            if ( loadFailed ) {
-
-                defaultNode = getDefaultSymbolNode();
-
-                Bounds bounds = defaultNode.getLayoutBounds();
-
-                originalWidth = bounds.getWidth();
-                originalHeight = bounds.getHeight();
-
-            }
-
         }
 
         String getFileName ( ) {
@@ -771,34 +779,8 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
             return originalWidth;
         }
 
-        Node getNode ( ) {
-            if ( isDefault() ) {
-                return defaultNode;
-            } else {
-
-                imageView.setImage(image);
-
-                return imageView;
-
-            }
-        }
-
-        boolean isDefault ( ) {
-            return ( defaultNode != null );
-        }
-
-        void setSize ( double width, double height, boolean preserveRatio ) {
-            if ( isDefault() ) {
-                ((DefaultSymbolNode) getNode()).setSize(width, height);
-            } else {
-
-                ImageView iv = (ImageView) getNode();
-
-                iv.setFitWidth(width);
-                iv.setFitHeight(height);
-                iv.setPreserveRatio(preserveRatio);
-
-            }
+        Image getImage ( ) {
+            return image;
         }
 
     }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -9,100 +9,50 @@
 package org.csstudio.display.builder.representation.javafx.widgets;
 
 
-import static org.csstudio.display.builder.representation.ToolkitRepresentation.logger;
-
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.logging.Level;
-import java.util.stream.Collectors;
 
-import org.csstudio.display.builder.model.ArrayWidgetProperty;
 import org.csstudio.display.builder.model.DirtyFlag;
-import org.csstudio.display.builder.model.DisplayModel;
-import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetProperty;
-import org.csstudio.display.builder.model.WidgetPropertyListener;
-import org.csstudio.display.builder.model.macros.MacroHandler;
-import org.csstudio.display.builder.model.util.ModelResourceUtil;
-import org.csstudio.display.builder.model.widgets.PVWidget;
 import org.csstudio.display.builder.model.widgets.SymbolWidget;
-import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.csstudio.javafx.Styles;
-import org.diirt.util.array.ListInt;
-import org.diirt.util.array.ListNumber;
-import org.diirt.vtype.VBoolean;
-import org.diirt.vtype.VEnum;
-import org.diirt.vtype.VEnumArray;
-import org.diirt.vtype.VNumber;
-import org.diirt.vtype.VNumberArray;
-import org.diirt.vtype.VString;
 import org.diirt.vtype.VType;
 
-import javafx.application.Platform;
 import javafx.beans.binding.Bindings;
-import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
-import javafx.geometry.Bounds;
-import javafx.geometry.Dimension2D;
-import javafx.geometry.Insets;
 import javafx.geometry.Pos;
+import javafx.scene.Group;
+import javafx.scene.Node;
 import javafx.scene.control.Label;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.scene.layout.AnchorPane;
-import javafx.scene.layout.Background;
-import javafx.scene.layout.BackgroundFill;
-import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.CornerRadii;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
+import javafx.scene.shape.Line;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.shape.StrokeLineCap;
+import javafx.scene.shape.StrokeType;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontWeight;
-import se.europeanspallationsource.xaos.components.SVG;
 
 
 /**
  * @author claudiorosati, European Spallation Source ERIC
  * @version 1.0.0 19 Jun 2017
  */
-public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, SymbolWidget> {
+public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, SymbolWidget> {
 
     private static final Executor EXECUTOR = Executors.newFixedThreadPool(8);
 
-    private static volatile Image defaultSymbol = null;
-
-    private int                                  arrayIndex            = 0;
-    private volatile boolean                     autoSize              = false;
-    private final DirtyFlag                      dirtyContent          = new DirtyFlag();
+    private Node                                 content;
     private final DirtyFlag                      dirtyGeometry         = new DirtyFlag();
-    private final DirtyFlag                      dirtyIndex            = new DirtyFlag();
     private final DirtyFlag                      dirtyStyle            = new DirtyFlag();
     private final DirtyFlag                      dirtyValue            = new DirtyFlag();
     private volatile boolean                     enabled               = true;
-    private final List<ImageContent>             imagesList            = Collections.synchronizedList(new ArrayList<>(4));
-    private final Map<String, ImageContent>      imagesMap             = Collections.synchronizedMap(new TreeMap<>());
-    private BorderPane                           imagePane;
-    private final WidgetPropertyListener<String> imagePropertyListener = this::imageChanged;
-    private ImageView                            imageView;
-    private Label                                indexLabel;
-    private Circle                               indexLabelBackground;
-    private Dimension2D                          maxSize               = new Dimension2D(0, 0);
-    private final ReentrantLock                  updatingSymbols       = new ReentrantLock();
-    private final AtomicBoolean                  updatingValue         = new AtomicBoolean(false);
+    private final Label                          indexLabel            = new Label();
+    private final Circle                         indexLabelBackground  = new Circle(16.0, Color.BLACK.deriveColor(0.0, 0.0, 0.0, 0.75));
 
     //  ---- imageIndex property
     private IntegerProperty imageIndex =  new SimpleIntegerProperty(-1);
@@ -116,130 +66,17 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
     }
 
     private void setImageIndex ( int imageIndex ) {
-        EXECUTOR.execute(() -> {
-
-            updatingSymbols.lock();
-
-            try {
-                Platform.runLater(() -> this.imageIndex.set(imageIndex));
-            } finally {
-                updatingSymbols.unlock();
-            }
-
-        });
-    }
-
-    //  ---- triggerContentUpdate property
-    private BooleanProperty triggerContentUpdate =  new SimpleBooleanProperty(false);
-
-    private boolean isTriggerContentUpdate ( ) {
-        return triggerContentUpdate.get();
-    }
-
-    private BooleanProperty triggerContentUpdateProperty ( ) {
-        return triggerContentUpdate;
-    }
-
-    private void setTriggerContentUpdate ( boolean triggerContentUpdate ) {
-        Platform.runLater(() -> this.triggerContentUpdate.set(triggerContentUpdate));
-    }
-
-    private void triggerContentUpdate() {
-        setTriggerContentUpdate(!isTriggerContentUpdate());
-    }
-
-    //  ---- triggerImageUpdate property
-    private BooleanProperty triggerImageUpdate =  new SimpleBooleanProperty(false);
-
-    private boolean isTriggerImageUpdate ( ) {
-        return triggerImageUpdate.get();
-    }
-
-    private BooleanProperty triggerImageUpdateProperty ( ) {
-        return triggerImageUpdate;
-    }
-
-    private void setTriggerImageUpdate ( boolean triggerImageUpdate ) {
-        Platform.runLater(() -> this.triggerImageUpdate.set(triggerImageUpdate));
-    }
-
-    private void triggerImageUpdate() {
-        setTriggerImageUpdate(!isTriggerImageUpdate());
-    }
-
-    /**
-     * Compute the maximum width and height of the given {@code widget} based on
-     * the its set of symbol images.
-     *
-     * @param widget The {@link SymbolWidget} whose size must be computed.
-     * @return A not {@code null} maximum dimension of the given {@code widget}.
-     */
-    public static Dimension2D computeMaximumSize ( final SymbolWidget widget ) {
-
-        Double[] max_size = new Double[] { 0.0, 0.0 };
-
-        widget.propSymbols().getValue().stream().forEach(s -> {
-
-            final String imageFile = s.getValue();
-
-            try {
-
-                final SymbolRepresentation representation = widget.getUserData(Widget.USER_DATA_REPRESENTATION);
-                final ImageContent ic = representation.imagesMap.containsKey(imageFile)
-                                      ? representation.imagesMap.get(imageFile)
-                                      : representation.createImageContent(imageFile);
-
-                if ( max_size[0] < ic.getOriginalWidth() ) {
-                    max_size[0] = ic.getOriginalWidth();
-                }
-                if ( max_size[1] < ic.getOriginalHeight() ) {
-                    max_size[1] = ic.getOriginalHeight();
-                }
-
-            } catch ( Exception ex ) {
-                //  The following message has proven to be annoying and not useful.
-                //logger.log(Level.WARNING, "Cannot obtain image size for {0} [{1}].", new Object[] { imageFile, ex.getMessage() });
-            }
-
-        });
-
-        return new Dimension2D(max_size[0], max_size[1]);
-
-    }
-
-    public static String resolveImageFile ( SymbolWidget widget, String imageFileName ) {
-
-        try {
-
-            String expandedFileName = MacroHandler.replace(widget.getMacrosOrProperties(), imageFileName);
-
-            //  Resolve new image file relative to the source widget model (not 'top'!).
-            //  Get the display model from the widget tied to this representation.
-            final DisplayModel widgetModel = widget.getDisplayModel();
-
-            // Resolve the image path using the parent model file path.
-            return ModelResourceUtil.resolveResource(widgetModel, expandedFileName);
-
-        } catch ( Exception ex ) {
-
-            logger.log(Level.WARNING, "Failure resolving image path: {0} [{1}].", new Object[] { imageFileName, ex.getMessage() });
-
-            return null;
-
-        }
-
-    }
-
-    private static boolean resourceExists ( String fileName ) {
-
-        try {
-            ModelResourceUtil.openResourceStream(fileName);
-        } catch ( Exception ex ) {
-            return false;
-        }
-
-        return true;
-
+//        EXECUTOR.execute(() -> {
+//
+//            updatingSymbols.lock();
+//
+//            try {
+//                Platform.runLater(() -> this.imageIndex.set(imageIndex));
+//            } finally {
+//                updatingSymbols.unlock();
+//            }
+//
+//        });
     }
 
     @Override
@@ -247,7 +84,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
 
         super.updateChanges();
 
-        boolean needsSVGResize = false;
+//        boolean needsSVGResize = false;
         Object value;
 
         if ( dirtyGeometry.checkAndClear() ) {
@@ -258,60 +95,82 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
                 jfx_node.setVisible((boolean) value);
             }
 
-            value = model_widget.propAutoSize().getValue();
-
-            if ( !Objects.equals(value, autoSize) ) {
-                autoSize = (boolean) value;
-            }
-
-            if ( autoSize ) {
-                model_widget.propWidth().setValue((int) Math.round(maxSize.getWidth()));
-                model_widget.propHeight().setValue((int) Math.round(maxSize.getHeight()));
-            }
+//            value = model_widget.propAutoSize().getValue();
+//
+//            if ( !Objects.equals(value, autoSize) ) {
+//                autoSize = (boolean) value;
+//            }
+//
+//            if ( autoSize ) {
+//                model_widget.propWidth().setValue((int) Math.round(maxSize.getWidth()));
+//                model_widget.propHeight().setValue((int) Math.round(maxSize.getHeight()));
+//            }
 
             double w = model_widget.propWidth().getValue();
             double h = model_widget.propHeight().getValue();
 
-            jfx_node.setLayoutX(model_widget.propX().getValue());
-            jfx_node.setLayoutY(model_widget.propY().getValue());
-            jfx_node.setPrefWidth(w);
-            jfx_node.setPrefHeight(h);
-
-            double minSize = Math.min(w, h);
-
-            indexLabelBackground.setRadius(Math.min(minSize / 2, 16.0));
-
-            needsSVGResize = true;
-
-        }
-
-        if ( dirtyIndex.checkAndClear() ) {
-            setImageIndex(model_widget.propInitialIndex().getValue());
-        }
-
-        if ( dirtyContent.checkAndClear() ) {
-
-            value = model_widget.propArrayIndex().getValue();
-
-            if ( !Objects.equals(value, arrayIndex) ) {
-                arrayIndex = Math.max(0, (int) value);
+            if ( w < 32 || h < 32 ) {
+                jfx_node.getChildren().remove(indexLabel);
+                jfx_node.getChildren().remove(indexLabelBackground);
+            } else {
+                if ( !jfx_node.getChildren().contains(indexLabelBackground) ) {
+                    jfx_node.getChildren().add(indexLabelBackground);
+                }
+                if ( !jfx_node.getChildren().contains(indexLabel) ) {
+                    jfx_node.getChildren().add(indexLabel);
+                }
             }
 
-            dirtyValue.mark();
+            jfx_node.setLayoutX(model_widget.propX().getValue());
+            jfx_node.setLayoutY(model_widget.propY().getValue());
+            jfx_node.setPrefSize(w, h);
+
+            if ( content != null ) {
+                if ( content instanceof DefaultSymbol ) {
+                    ((DefaultSymbol) content).setSize(w, h);
+                } else if ( content instanceof Region ) {
+                    ((Region) content).setPrefSize(w, h);
+                }
+            }
+
+
+
+
+//            double minSize = Math.min(w, h);
+//
+//            indexLabelBackground.setRadius(Math.min(minSize / 2, 16.0));
+//
+//            needsSVGResize = true;
 
         }
+
+//        if ( dirtyIndex.checkAndClear() ) {
+//            setImageIndex(model_widget.propInitialIndex().getValue());
+//        }
+//
+//        if ( dirtyContent.checkAndClear() ) {
+//
+//            value = model_widget.propArrayIndex().getValue();
+//
+//            if ( !Objects.equals(value, arrayIndex) ) {
+//                arrayIndex = Math.max(0, (int) value);
+//            }
+//
+//            dirtyValue.mark();
+//
+//        }
 
         if ( dirtyStyle.checkAndClear() ) {
 
-            value = model_widget.propPreserveRatio().getValue();
-
-            if ( !Objects.equals(value, imageView.isPreserveRatio()) ) {
-
-                imageView.setPreserveRatio((boolean) value);
-
-                needsSVGResize = true;
-
-            }
+//            value = model_widget.propPreserveRatio().getValue();
+//
+//            if ( !Objects.equals(value, imageView.isPreserveRatio()) ) {
+//
+//                imageView.setPreserveRatio((boolean) value);
+//
+//                needsSVGResize = true;
+//
+//            }
 
             value = model_widget.propEnabled().getValue();
 
@@ -330,261 +189,234 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
                 indexLabelBackground.setVisible((boolean) value);
             }
 
-            if ( model_widget.propTransparent().getValue() ) {
-                jfx_node.setBackground(null);
-            } else {
-                jfx_node.setBackground(new Background(new BackgroundFill(JFXUtil.convert(model_widget.propBackgroundColor().getValue()), CornerRadii.EMPTY, Insets.EMPTY)));
-            }
-
-            value = model_widget.propRotation().getValue();
-
-            if ( !Objects.equals(value, imagePane.getRotate()) ) {
-                imagePane.setRotate((double) value);
-            }
-
-        }
-
-        if ( dirtyValue.checkAndClear() && updatingValue.compareAndSet(false, true) ) {
-
-            int idx = Integer.MIN_VALUE;    //  Marker indicating no valid value.
-
-            try {
-
-                value = model_widget.runtimePropValue().getValue();
-
-                if ( value != null ) {
-                    if ( PVWidget.RUNTIME_VALUE_NO_PV == value ) {
-                        idx = model_widget.propInitialIndex().getValue();
-                    } else if ( value instanceof VBoolean ) {
-                        idx = ((VBoolean) value).getValue() ? 1 : 0;
-                    } else if ( value instanceof VString ) {
-                        try {
-                            idx = Integer.parseInt(((VString) value).getValue());
-                        } catch ( NumberFormatException nfex ) {
-                            logger.log(Level.FINE, "Failure parsing the string value: {0} [{1}].", new Object[] { ((VString) value).getValue(), nfex.getMessage() });
-                        }
-                    } else if ( value instanceof VNumber ) {
-                        idx = ((VNumber) value).getValue().intValue();
-                    } else if ( value instanceof VEnum ) {
-                        idx = ((VEnum) value).getIndex();
-                    } else if ( value instanceof VNumberArray ) {
-
-                        ListNumber array = ((VNumberArray) value).getData();
-
-                        if ( array.size() > 0 ) {
-                            idx = array.getInt(Math.min(arrayIndex, array.size() - 1));
-                        }
-
-                    } else if ( value instanceof VEnumArray ) {
-
-                        ListInt array = ((VEnumArray) value).getIndexes();
-
-                        if ( array.size() > 0 ) {
-                            idx = array.getInt(Math.min(arrayIndex, array.size() - 1));
-                        }
-
-                    }
-                }
-
-            } finally {
-                updatingValue.set(false);
-            }
-
-            if ( idx != Integer.MIN_VALUE ) {
-                //  Valid value.
-                setImageIndex(idx);
-            }
+//            if ( model_widget.propTransparent().getValue() ) {
+//                jfx_node.setBackground(null);
+//            } else {
+//                jfx_node.setBackground(new Background(new BackgroundFill(JFXUtil.convert(model_widget.propBackgroundColor().getValue()), CornerRadii.EMPTY, Insets.EMPTY)));
+//            }
+//
+//            value = model_widget.propRotation().getValue();
+//
+//            if ( !Objects.equals(value, imagePane.getRotate()) ) {
+//                imagePane.setRotate((double) value);
+//            }
 
         }
 
-        if ( needsSVGResize ) {
-            imagesList.stream().filter(ic -> ic.isSVG()).forEach(ic -> {
-
-                double widgetWidth = model_widget.propWidth().getValue().doubleValue();
-                double widgetHeight = model_widget.propHeight().getValue().doubleValue();
-                double symbolWidth = widgetWidth;
-                double symbolHeight = widgetHeight;
-
-                if ( model_widget.propPreserveRatio().getValue() ) {
-
-                    double wPrime = symbolHeight * ic.getOriginalRatio();
-                    double hPrime = symbolWidth / ic.getOriginalRatio();
-
-                    if ( wPrime < symbolWidth ) {
-                        symbolHeight = hPrime;
-                    } else if ( hPrime < symbolHeight ) {
-                        symbolWidth = wPrime;
-                    }
-
-                }
-
-                double finalSymbolWidth = symbolWidth;
-                double finalSymbolHeight = symbolHeight;
-                double cos_a = Math.cos(Math.toRadians(model_widget.propRotation().getValue()));
-                double sin_a = Math.sin(Math.toRadians(model_widget.propRotation().getValue()));
-                double pic_bb_w = symbolWidth * Math.abs(cos_a) + symbolHeight * Math.abs(sin_a);
-                double pic_bb_h = symbolWidth * Math.abs(sin_a) + symbolHeight * Math.abs(cos_a);
-                double scale_fac = Math.min(widgetWidth / pic_bb_w, widgetHeight / pic_bb_h);
-
-                if ( scale_fac < 1.0 ) {
-                    finalSymbolWidth = (int) Math.floor(scale_fac * symbolWidth);
-                    finalSymbolHeight = (int) Math.floor(scale_fac * symbolHeight);
-                }
-
-                SVG svg = ic.getSVG();
-                Bounds bounds = svg.getLayoutBounds();
-                double boundsWidth = bounds.getWidth();
-                double boundsHeight = bounds.getHeight();
-
-                svg.setScaleX(finalSymbolWidth / boundsWidth);
-                svg.setScaleY(finalSymbolHeight / boundsHeight);
-
-                if ( finalSymbolWidth < boundsWidth && widgetWidth <= boundsWidth ) {
-                    svg.setTranslateX(( widgetWidth - boundsWidth ) / 2.0);
-                } else {
-                    svg.setTranslateX(0);
-                }
-
-                if ( finalSymbolHeight < boundsHeight && widgetHeight <= boundsHeight ) {
-                    svg.setTranslateY(( widgetHeight - boundsHeight ) / 2.0);
-                } else {
-                    svg.setTranslateY(0);
-                }
-
-            });
-        }
+//        if ( dirtyValue.checkAndClear() && updatingValue.compareAndSet(false, true) ) {
+//
+//            int idx = Integer.MIN_VALUE;    // Marker indicating no valid value.
+//
+//            try {
+//
+//                value = model_widget.runtimePropValue().getValue();
+//
+//                if ( value != null ) {
+//                    if ( PVWidget.RUNTIME_VALUE_NO_PV == value ) {
+//                        idx = model_widget.propInitialIndex().getValue();
+//                    } else if ( value instanceof VBoolean ) {
+//                        idx = ( (VBoolean) value ).getValue() ? 1 : 0;
+//                    } else if ( value instanceof VString ) {
+//                        try {
+//                            idx = Integer.parseInt(( (VString) value ).getValue());
+//                        } catch ( NumberFormatException nfex ) {
+//                            logger.log(Level.FINE, "Failure parsing the string value: {0} [{1}].", new Object[] { ( (VString) value ).getValue(), nfex.getMessage() });
+//                        }
+//                    } else if ( value instanceof VNumber ) {
+//                        idx = ( (VNumber) value ).getValue().intValue();
+//                    } else if ( value instanceof VEnum ) {
+//                        idx = ( (VEnum) value ).getIndex();
+//                    } else if ( value instanceof VNumberArray ) {
+//
+//                        ListNumber array = ( (VNumberArray) value ).getData();
+//
+//                        if ( array.size() > 0 ) {
+//                            idx = array.getInt(Math.min(arrayIndex, array.size() - 1));
+//                        }
+//
+//                    } else if ( value instanceof VEnumArray ) {
+//
+//                        ListInt array = ( (VEnumArray) value ).getIndexes();
+//
+//                        if ( array.size() > 0 ) {
+//                            idx = array.getInt(Math.min(arrayIndex, array.size() - 1));
+//                        }
+//
+//                    }
+//                }
+//
+//            } finally {
+//                updatingValue.set(false);
+//            }
+//
+//            if ( idx != Integer.MIN_VALUE ) {
+//                // Valid value.
+//                setImageIndex(idx);
+//            }
+//
+//        }
+//
+//        if ( needsSVGResize ) {
+//            imagesList.stream().filter(ic -> ic.isSVG()).forEach(ic -> {
+//
+//                double widgetWidth = model_widget.propWidth().getValue().doubleValue();
+//                double widgetHeight = model_widget.propHeight().getValue().doubleValue();
+//                double symbolWidth = widgetWidth;
+//                double symbolHeight = widgetHeight;
+//
+//                if ( model_widget.propPreserveRatio().getValue() ) {
+//
+//                    double wPrime = symbolHeight * ic.getOriginalRatio();
+//                    double hPrime = symbolWidth / ic.getOriginalRatio();
+//
+//                    if ( wPrime < symbolWidth ) {
+//                        symbolHeight = hPrime;
+//                    } else if ( hPrime < symbolHeight ) {
+//                        symbolWidth = wPrime;
+//                    }
+//
+//                }
+//
+//                double finalSymbolWidth = symbolWidth;
+//                double finalSymbolHeight = symbolHeight;
+//                double cos_a = Math.cos(Math.toRadians(model_widget.propRotation().getValue()));
+//                double sin_a = Math.sin(Math.toRadians(model_widget.propRotation().getValue()));
+//                double pic_bb_w = symbolWidth * Math.abs(cos_a) + symbolHeight * Math.abs(sin_a);
+//                double pic_bb_h = symbolWidth * Math.abs(sin_a) + symbolHeight * Math.abs(cos_a);
+//                double scale_fac = Math.min(widgetWidth / pic_bb_w, widgetHeight / pic_bb_h);
+//
+//                if ( scale_fac < 1.0 ) {
+//                    finalSymbolWidth = (int) Math.floor(scale_fac * symbolWidth);
+//                    finalSymbolHeight = (int) Math.floor(scale_fac * symbolHeight);
+//                }
+//
+//                SVG svg = ic.getSVG();
+//                Bounds bounds = svg.getLayoutBounds();
+//                double boundsWidth = bounds.getWidth();
+//                double boundsHeight = bounds.getHeight();
+//
+//                svg.setScaleX(finalSymbolWidth / boundsWidth);
+//                svg.setScaleY(finalSymbolHeight / boundsHeight);
+//
+//                if ( finalSymbolWidth < boundsWidth && widgetWidth <= boundsWidth ) {
+//                    svg.setTranslateX(( widgetWidth - boundsWidth ) / 2.0);
+//                } else {
+//                    svg.setTranslateX(0);
+//                }
+//
+//                if ( finalSymbolHeight < boundsHeight && widgetHeight <= boundsHeight ) {
+//                    svg.setTranslateY(( widgetHeight - boundsHeight ) / 2.0);
+//                } else {
+//                    svg.setTranslateY(0);
+//                }
+//
+//            });
+//        }
 
     }
 
-    @Override
-    protected AnchorPane createJFXNode ( ) throws Exception {
+  @Override
+  protected StackPane createJFXNode ( ) throws Exception {
 
-        setImageIndex(Math.max(model_widget.propInitialIndex().getValue(), 0));
+//      setImageIndex(Math.max(model_widget.propInitialIndex().getValue(), 0));
 
-        autoSize = model_widget.propAutoSize().getValue();
+//      autoSize = model_widget.propAutoSize().getValue();
+      content = new DefaultSymbol();
 
-        AnchorPane symbol = new AnchorPane();
+      StackPane symbol = new StackPane();
 
-            imagePane = new BorderPane();
+//          imagePane = new BorderPane();
+//
+//              imageView = new ImageView();
+//
+//              imageView.setPreserveRatio(model_widget.propPreserveRatio().getValue());
+//              imageView.setSmooth(true);
+//              imageView.fitHeightProperty().bind(symbol.prefHeightProperty());
+//              imageView.fitWidthProperty().bind(symbol.prefWidthProperty());
+//              imageView.imageProperty().bind(Bindings.createObjectBinding(
+//                  () -> getDisplayable(ic -> ic.isImage(), ic -> ic.getImage(), getDefaultSymbol()),
+//                  imageIndexProperty(),
+//                  triggerImageUpdateProperty()
+//              ));
+//
+//          imagePane.setPrefWidth(model_widget.propWidth().getValue());
+//          imagePane.setPrefHeight(model_widget.propHeight().getValue());
+//          imagePane.setRotate(model_widget.propRotation().getValue());
+//          imagePane.centerProperty().bind(Bindings.createObjectBinding(
+//              () -> getDisplayable(ic -> ic.isSVG(), ic -> ic.getSVG(), imageView),
+//              imageIndexProperty(),
+//              triggerContentUpdateProperty()
+//          ));
+//
+//          AnchorPane.setLeftAnchor(imagePane, 0.0);
+//          AnchorPane.setRightAnchor(imagePane, 0.0);
+//          AnchorPane.setTopAnchor(imagePane, 0.0);
+//          AnchorPane.setBottomAnchor(imagePane, 0.0);
 
-                imageView = new ImageView();
+      indexLabelBackground.setStroke(Color.LIGHTGRAY.deriveColor(0.0, 1.0, 1.0, 0.75));
+      indexLabelBackground.setVisible(model_widget.propShowIndex().getValue());
 
-                imageView.setPreserveRatio(model_widget.propPreserveRatio().getValue());
-                imageView.setSmooth(true);
-                imageView.fitHeightProperty().bind(symbol.prefHeightProperty());
-                imageView.fitWidthProperty().bind(symbol.prefWidthProperty());
-                imageView.imageProperty().bind(Bindings.createObjectBinding(
-                    () -> getDisplayable(ic -> ic.isImage(), ic -> ic.getImage(), getDefaultSymbol()),
-                    imageIndexProperty(),
-                    triggerImageUpdateProperty()
-                ));
+      indexLabel.setAlignment(Pos.CENTER);
+      indexLabel.setFont(Font.font(indexLabel.getFont().getFamily(), FontWeight.BOLD, 16));
+      indexLabel.setTextFill(Color.WHITE);
+      indexLabel.setVisible(model_widget.propShowIndex().getValue());
+      indexLabel.textProperty().bind(Bindings.convert(imageIndexProperty()));
 
-            imagePane.setPrefWidth(model_widget.propWidth().getValue());
-            imagePane.setPrefHeight(model_widget.propHeight().getValue());
-            imagePane.setRotate(model_widget.propRotation().getValue());
-            imagePane.centerProperty().bind(Bindings.createObjectBinding(
-                () -> getDisplayable(ic -> ic.isSVG(), ic -> ic.getSVG(), imageView),
-                imageIndexProperty(),
-                triggerContentUpdateProperty()
-            ));
+      symbol.getChildren().addAll(content, indexLabelBackground, indexLabel);
 
-            AnchorPane.setLeftAnchor(imagePane, 0.0);
-            AnchorPane.setRightAnchor(imagePane, 0.0);
-            AnchorPane.setTopAnchor(imagePane, 0.0);
-            AnchorPane.setBottomAnchor(imagePane, 0.0);
+//      if ( model_widget.propTransparent().getValue() ) {
+//          symbol.setBackground(null);
+//      } else {
+//          symbol.setBackground(new Background(new BackgroundFill(JFXUtil.convert(model_widget.propBackgroundColor().getValue()), CornerRadii.EMPTY, Insets.EMPTY)));
+//      }
+//
+//      enabled = model_widget.propEnabled().getValue();
+//
+//      Styles.update(symbol, Styles.NOT_ENABLED, !enabled);
+//
+//      imageChanged(null, null, null);
 
-            BorderPane circlePane = new BorderPane();
+      return symbol;
 
-                indexLabelBackground = new Circle(16.0, Color.BLACK.deriveColor(0.0, 0.0, 0.0, 0.75));
-
-                indexLabelBackground.setStroke(Color.LIGHTGRAY.deriveColor(0.0, 1.0, 1.0, 0.75));
-                indexLabelBackground.setVisible(model_widget.propShowIndex().getValue());
-
-            circlePane.setCenter(indexLabelBackground);
-
-            AnchorPane.setLeftAnchor(circlePane, 0.0);
-            AnchorPane.setRightAnchor(circlePane, 0.0);
-            AnchorPane.setTopAnchor(circlePane, 0.0);
-            AnchorPane.setBottomAnchor(circlePane, 0.0);
-
-            indexLabel = new Label();
-
-            indexLabel.setAlignment(Pos.CENTER);
-            indexLabel.setFont(Font.font(indexLabel.getFont().getFamily(), FontWeight.BOLD, 16));
-            indexLabel.setTextFill(Color.WHITE);
-            indexLabel.setVisible(model_widget.propShowIndex().getValue());
-            indexLabel.textProperty().bind(Bindings.convert(imageIndexProperty()));
-
-            AnchorPane.setLeftAnchor(indexLabel, 0.0);
-            AnchorPane.setRightAnchor(indexLabel, 0.0);
-            AnchorPane.setTopAnchor(indexLabel, 0.0);
-            AnchorPane.setBottomAnchor(indexLabel, 0.0);
-
-        symbol.getChildren().addAll(imagePane, circlePane, indexLabel);
-
-        if ( model_widget.propTransparent().getValue() ) {
-            symbol.setBackground(null);
-        } else {
-            symbol.setBackground(new Background(new BackgroundFill(JFXUtil.convert(model_widget.propBackgroundColor().getValue()), CornerRadii.EMPTY, Insets.EMPTY)));
-        }
-
-        enabled = model_widget.propEnabled().getValue();
-
-        Styles.update(symbol, Styles.NOT_ENABLED, !enabled);
-
-        imageChanged(null, null, null);
-
-        return symbol;
-
-    }
+  }
 
     @Override
     protected void registerListeners ( ) {
 
         super.registerListeners();
 
-        model_widget.propArrayIndex().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propPVName().addPropertyListener(this::contentChanged);
-
-        model_widget.propSymbols().addPropertyListener(this::imagesChanged);
-        model_widget.propSymbols().getValue().stream().forEach(p -> {
-            p.removePropertyListener(imagePropertyListener);
-            p.addPropertyListener(imagePropertyListener);
-        });
-
-        model_widget.propInitialIndex().addPropertyListener(this::initialIndexChanged);
-
-        model_widget.propAutoSize().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propVisible().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propX().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propY().addUntypedPropertyListener(this::geometryChanged);
+//        model_widget.propArrayIndex().addUntypedPropertyListener(this::contentChanged);
+//        model_widget.propPVName().addPropertyListener(this::contentChanged);
+//
+//        model_widget.propSymbols().addPropertyListener(this::imagesChanged);
+//        model_widget.propSymbols().getValue().stream().forEach(p -> {
+//            p.removePropertyListener(imagePropertyListener);
+//            p.addPropertyListener(imagePropertyListener);
+//        });
+//
+//        model_widget.propInitialIndex().addPropertyListener(this::initialIndexChanged);
+//
+//        model_widget.propAutoSize().addUntypedPropertyListener(this::geometryChanged);
+//        model_widget.propVisible().addUntypedPropertyListener(this::geometryChanged);
+//        model_widget.propX().addUntypedPropertyListener(this::geometryChanged);
+//        model_widget.propY().addUntypedPropertyListener(this::geometryChanged);
         model_widget.propWidth().addUntypedPropertyListener(this::geometryChanged);
         model_widget.propHeight().addUntypedPropertyListener(this::geometryChanged);
 
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::styleChanged);
+//        model_widget.propBackgroundColor().addUntypedPropertyListener(this::styleChanged);
         model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propPreserveRatio().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propRotation().addUntypedPropertyListener(this::styleChanged);
+//        model_widget.propPreserveRatio().addUntypedPropertyListener(this::styleChanged);
+//        model_widget.propRotation().addUntypedPropertyListener(this::styleChanged);
         model_widget.propShowIndex().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::styleChanged);
+//        model_widget.propTransparent().addUntypedPropertyListener(this::styleChanged);
+//
+//        if ( toolkit.isEditMode() ) {
+//            dirtyValue.checkAndClear();
+//        } else {
+//            model_widget.runtimePropValue().addPropertyListener(this::valueChanged);
+//            valueChanged(null, null, null);
+//        }
 
-        if ( toolkit.isEditMode() ) {
-            dirtyValue.checkAndClear();
-        } else {
-            model_widget.runtimePropValue().addPropertyListener(this::valueChanged);
-            valueChanged(null, null, null);
-        }
-
-    }
-
-    private void contentChanged ( final WidgetProperty<?> property, final Object oldValue, final Object newValue ) {
-        dirtyContent.mark();
-        toolkit.scheduleUpdate(this);
-    }
-
-
-    private ImageContent createImageContent ( String fileName ) {
-        return new ImageContent(fileName);
     }
 
     private void geometryChanged ( final WidgetProperty<?> property, final Object oldValue, final Object newValue ) {
@@ -592,259 +424,9 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
         toolkit.scheduleUpdate(this);
     }
 
-    private Image getDefaultSymbol() {
-
-        if ( defaultSymbol == null ) {
-            synchronized ( SymbolRepresentation.class ) {
-                if ( defaultSymbol == null ) {
-                    defaultSymbol = loadDefaultSymbol();
-                }
-            }
-        }
-
-        return defaultSymbol;
-
-    }
-
-    private <T> T  getDisplayable( Predicate<ImageContent> predicate, Function<ImageContent, T> getter, T defaultDisplayable ) {
-
-        int index = getImageIndex();
-
-        if ( index >= 0 && index < imagesList.size() ) {
-
-            ImageContent imageContent = imagesList.get(index);
-
-            if ( predicate.test(imageContent) ) {
-                return getter.apply(imageContent);
-            } else {
-                return defaultDisplayable;
-            }
-
-        } else {
-            return defaultDisplayable;
-        }
-
-    }
-
-    private void imageChanged ( final WidgetProperty<String> property, final String oldValue, final String newValue ) {
-        EXECUTOR.execute(() -> {
-
-            updateSymbols();
-
-            dirtyContent.mark();
-            toolkit.scheduleUpdate(this);
-
-        });
-    }
-
-    private void imagesChanged ( final WidgetProperty<List<WidgetProperty<String>>> property, final List<WidgetProperty<String>> oldValue, final List<WidgetProperty<String>> newValue ) {
-        EXECUTOR.execute(() -> {
-
-            updateSymbols();
-
-            if ( oldValue != null ) {
-                oldValue.stream().forEach(p -> p.removePropertyListener(imagePropertyListener));
-            }
-
-            if ( newValue != null ) {
-                newValue.stream().forEach(p -> p.addPropertyListener(imagePropertyListener));
-            }
-
-            dirtyContent.mark();
-            toolkit.scheduleUpdate(this);
-
-        });
-    }
-
-    private void initialIndexChanged ( final WidgetProperty<?> property, final Object oldValue, final Object newValue ) {
-        dirtyIndex.mark();
-        toolkit.scheduleUpdate(this);
-    }
-
-    private Image loadDefaultSymbol() {
-
-        String imageFileName = resolveImageFile(model_widget, SymbolWidget.DEFAULT_SYMBOL);
-
-        try {
-            //  Open the image from the stream created from the resource file.
-            return new Image(ModelResourceUtil.openResourceStream(imageFileName));
-        } catch ( Exception ex ) {
-            logger.log(Level.WARNING, "Failure loading image: {0} [{1}].", new Object[] { SymbolWidget.DEFAULT_SYMBOL, ex.getMessage() });
-        }
-
-        return null;
-
-    }
-
     private void styleChanged ( final WidgetProperty<?> property, final Object oldValue, final Object newValue ) {
         dirtyStyle.mark();
         toolkit.scheduleUpdate(this);
-    }
-
-    /**
-     * Fix the file names imported from BOY.
-     */
-    private void updateImportedSymbols ( ) {
-
-        try {
-
-            ArrayWidgetProperty<WidgetProperty<String>> propSymbols = model_widget.propSymbols();
-            List<String> fileNames = new ArrayList<>(2);
-
-            switch ( model_widget.getImportedFrom() ) {
-                case "org.csstudio.opibuilder.widgets.ImageBoolIndicator":
-                    return;
-                case "org.csstudio.opibuilder.widgets.symbol.bool.BoolMonitorWidget": {
-
-                        String imageFileName = propSymbols.getElement(0).getValue();
-                        int dotIndex = imageFileName.lastIndexOf('.');
-                        String onImageFileName = imageFileName.substring(0, dotIndex) + " On" + imageFileName.substring(dotIndex);
-                        String offImageFileName = imageFileName.substring(0, dotIndex) + " Off" + imageFileName.substring(dotIndex);
-
-                        if ( resourceExists(resolveImageFile(model_widget, onImageFileName)) ) {
-                            fileNames.add(onImageFileName);
-                        } else {
-                            fileNames.add(imageFileName);
-                        }
-
-                        if ( resourceExists(resolveImageFile(model_widget, offImageFileName)) ) {
-                            fileNames.add(offImageFileName);
-                        } else {
-                            fileNames.add(imageFileName);
-                        }
-
-                    }
-                    break;
-                case "org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget": {
-
-                        String imageFileName = propSymbols.getElement(0).getValue();
-                        int dotIndex = imageFileName.lastIndexOf('.');
-                        int spaceIndex = imageFileName.lastIndexOf(' ');
-
-                        try {
-                            model_widget.propInitialIndex().setValue(Integer.parseInt(imageFileName.substring(1 + spaceIndex, dotIndex)));
-                        } catch ( NumberFormatException nfex ) {
-                            logger.log(Level.WARNING, "Imported image file doesn't contain state value [{0}].", imageFileName);
-                        }
-
-                        int index = 0;
-
-                        while ( true ) {
-
-                            String nthImageFileName = MessageFormat.format(
-                                "{0} {1,number,#########0}{2}",
-                                imageFileName.substring(0, spaceIndex),
-                                index,
-                                imageFileName.substring(dotIndex)
-                            );
-
-                            if ( resourceExists(resolveImageFile(model_widget, nthImageFileName)) ) {
-                                fileNames.add(nthImageFileName);
-                            } else {
-                                break;
-                            }
-
-                            index++;
-
-                        }
-
-                    }
-                    break;
-                default:
-                    logger.log(Level.WARNING, "Invalid imported type [{0}].", model_widget.getImportedFrom());
-                    return;
-            }
-
-            for ( int i = 0; i < fileNames.size(); i++ ) {
-                model_widget.addOrReplaceSymbol(i, fileNames.get(i));
-            }
-
-        } finally {
-            model_widget.clearImportedFrom();
-        }
-
-    }
-
-    private synchronized void updateSymbols ( ) {
-
-        updatingSymbols.lock();
-
-        try {
-
-            int oldIndex = getImageIndex();
-
-            try {
-
-                ArrayWidgetProperty<WidgetProperty<String>> propSymbols = model_widget.propSymbols();
-                List<WidgetProperty<String>> fileNames = propSymbols.getValue();
-
-                if ( model_widget.getImportedFrom() != null ) {
-                    updateImportedSymbols();
-                }
-
-                if ( fileNames == null ) {
-                    logger.log(Level.WARNING, "Empty list of file names.");
-                } else {
-
-                    imagesList.clear();
-
-                    fileNames.stream().forEach(f -> {
-
-                        String fileName = f.getValue();
-                        ImageContent imageContent = imagesMap.get(fileName);
-
-                        if ( imageContent == null ) {
-
-                            imageContent = createImageContent(fileName);
-
-                            if ( imageContent.isValid() ) {
-                                imagesMap.put(fileName, imageContent);
-                            }
-
-                        }
-
-                        if ( imageContent.isValid() ) {
-                            imagesList.add(imageContent);
-                        }
-
-                    });
-
-                    Set<String> toBeRemoved = imagesMap.keySet().stream().filter(f -> !imagesList.contains(imagesMap.get(f))).collect(Collectors.toSet());
-
-                    toBeRemoved.stream().forEach(f -> imagesMap.remove(f));
-
-                }
-
-            } finally {
-
-                int newImageIndex = Math.min(Math.max(getImageIndex(), 0), imagesList.size() - 1);
-
-                maxSize = computeMaximumSize(model_widget);
-
-                if ( oldIndex == newImageIndex && oldIndex >= 0 ) {
-
-                    ImageContent imageContent = imagesList.get(getImageIndex());
-
-                    if ( imageContent.isSVG() || ( imageContent.isImage() && imagePane.getCenter() != imageView ) ) {
-                        Platform.runLater(() -> triggerContentUpdate());
-                    } else if ( imageContent.isImage() ) {
-                        Platform.runLater(() -> triggerImageUpdate());
-                    }
-
-                } else if ( oldIndex != newImageIndex ) {
-                    setImageIndex(newImageIndex);
-                }
-
-                dirtyGeometry.mark();
-                dirtyValue.mark();
-                toolkit.scheduleUpdate(this);
-
-            }
-
-        } finally {
-            updatingSymbols.unlock();
-        }
-
     }
 
     private void valueChanged ( final WidgetProperty<? extends VType> property, final VType oldValue, final VType newValue ) {
@@ -852,103 +434,580 @@ public class SymbolRepresentation extends RegionBaseRepresentation<AnchorPane, S
         toolkit.scheduleUpdate(this);
     }
 
-    private class ImageContent {
 
-        private Image image;
-        private double originalHeight;
-        private double originalWidth;
-        private SVG svg;
 
-        ImageContent ( String fileName ) {
 
-            boolean loadFailed = true;
-            String imageFileName = resolveImageFile(model_widget, fileName);
 
-            if ( imageFileName != null ) {
-                if ( imageFileName.toLowerCase().endsWith(".svg") ) {
-                    try {
 
-                        // Open the image from the stream created from the resource file
-                        svg = SVG.load(ModelResourceUtil.openResourceStream(imageFileName));
 
-                        Bounds bounds = svg.getLayoutBounds();
 
-                        originalWidth = bounds.getWidth();
-                        originalHeight = bounds.getHeight();
-                        image = null;
-                        loadFailed = false;
 
-                    } catch ( Exception ex ) {
-                        logger.log(Level.WARNING, "Failure loading SVG image file: ({0}) {1} [{2}].", new Object[] { fileName, imageFileName, ex.getMessage() });
-                    }
-                } else {
-                    try {
-                        //  Open the image from the stream created from the resource file.
-                        image = new Image(ModelResourceUtil.openResourceStream(imageFileName));
-                        originalWidth = image.getWidth();
-                        originalHeight = image.getHeight();
-                        svg = null;
-                        loadFailed = false;
-                    } catch ( Exception ex ) {
-                        logger.log(Level.WARNING, "Failure loading image: ({0}) {1} [{2}].", new Object[] { fileName, imageFileName, ex.getMessage() });
-                    }
-                }
-            }
 
-            if ( loadFailed ) {
 
-                imageFileName = resolveImageFile(model_widget, SymbolWidget.DEFAULT_SYMBOL);
 
-                try {
-                    //  Open the image from the stream created from the resource file.
-                    image = getDefaultSymbol();
-                    originalWidth = image.getWidth();
-                    originalHeight = image.getHeight();
-                    svg = null;
-                } catch ( Exception ex ) {
-                    logger.log(Level.WARNING, "Failure loading image: ({0}) {1} [{2}].", new Object[] { fileName, imageFileName, ex.getMessage() });
-                    image = null;
-                    svg = null;
-                    originalWidth = Double.NaN;
-                    originalHeight = Double.NaN;
-                }
 
-            }
+
+
+
+    private class DefaultSymbol extends Group {
+
+        private final Rectangle r;
+        private final Line l1;
+        private final Line l2;
+
+        DefaultSymbol() {
+
+            setAutoSizeChildren(true);
+            setManaged(true);
+
+            int w = 100;
+            int h = 100;
+
+            r = new Rectangle(0, 0, w, h);
+
+            r.setFill(null);
+            r.setArcHeight(0);
+            r.setArcWidth(0);
+            r.setStroke(Color.BLACK);
+            r.setStrokeType(StrokeType.INSIDE);
+
+            l1 = new Line(0.5, 0.5, w - 0.5, h - 0.5);
+
+            l1.setStroke(Color.BLACK);
+            l1.setStrokeLineCap(StrokeLineCap.BUTT);
+
+            l2 = new Line(0.5, h - 0.5, w - 0.5, 0.5);
+
+            l2.setStroke(Color.BLACK);
+            l2.setStrokeLineCap(StrokeLineCap.BUTT);
+
+            getChildren().add(r);
+            getChildren().add(l1);
+            getChildren().add(l2);
 
         }
 
-        Image getImage() {
-            return image;
-        }
+        public void setSize ( double w, double h ) {
 
-        double getOriginalHeight() {
-            return originalHeight;
-        }
+            r.setWidth(w);
+            r.setHeight(h);
 
-        double getOriginalRatio() {
-            return originalWidth / originalHeight;
-        }
+            l1.setEndX(w - 0.5);
+            l1.setEndY(h - 0.5);
 
-        double getOriginalWidth() {
-            return originalWidth;
-        }
+            l2.setEndX(w - 0.5);
+            l2.setStartY(h - 0.5);
 
-        SVG getSVG() {
-            return svg;
-        }
-
-        boolean isImage() {
-            return ( image != null );
-        }
-
-        boolean isSVG() {
-            return ( svg != null );
-        }
-
-        boolean isValid() {
-            return ( isImage() || isSVG() );
         }
 
     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+//    private static volatile Image defaultSymbol = null;
+//
+//    private int                                  arrayIndex            = 0;
+//    private volatile boolean                     autoSize              = false;
+//    private final DirtyFlag                      dirtyContent          = new DirtyFlag();
+//    private final DirtyFlag                      dirtyIndex            = new DirtyFlag();
+//    private final List<ImageContent>             imagesList            = Collections.synchronizedList(new ArrayList<>(4));
+//    private final Map<String, ImageContent>      imagesMap             = Collections.synchronizedMap(new TreeMap<>());
+//    private BorderPane                           imagePane;
+//    private final WidgetPropertyListener<String> imagePropertyListener = this::imageChanged;
+//    private ImageView                            imageView;
+//    private Dimension2D                          maxSize               = new Dimension2D(0, 0);
+//    private final ReentrantLock                  updatingSymbols       = new ReentrantLock();
+//    private final AtomicBoolean                  updatingValue         = new AtomicBoolean(false);
+//
+//    //  ---- triggerContentUpdate property
+//    private BooleanProperty triggerContentUpdate =  new SimpleBooleanProperty(false);
+//
+//    private boolean isTriggerContentUpdate ( ) {
+//        return triggerContentUpdate.get();
+//    }
+//
+//    private BooleanProperty triggerContentUpdateProperty ( ) {
+//        return triggerContentUpdate;
+//    }
+//
+//    private void setTriggerContentUpdate ( boolean triggerContentUpdate ) {
+//        Platform.runLater(() -> this.triggerContentUpdate.set(triggerContentUpdate));
+//    }
+//
+//    private void triggerContentUpdate() {
+//        setTriggerContentUpdate(!isTriggerContentUpdate());
+//    }
+//
+//    //  ---- triggerImageUpdate property
+//    private BooleanProperty triggerImageUpdate =  new SimpleBooleanProperty(false);
+//
+//    private boolean isTriggerImageUpdate ( ) {
+//        return triggerImageUpdate.get();
+//    }
+//
+//    private BooleanProperty triggerImageUpdateProperty ( ) {
+//        return triggerImageUpdate;
+//    }
+//
+//    private void setTriggerImageUpdate ( boolean triggerImageUpdate ) {
+//        Platform.runLater(() -> this.triggerImageUpdate.set(triggerImageUpdate));
+//    }
+//
+//    private void triggerImageUpdate() {
+//        setTriggerImageUpdate(!isTriggerImageUpdate());
+//    }
+//
+//    /**
+//     * Compute the maximum width and height of the given {@code widget} based on
+//     * the its set of symbol images.
+//     *
+//     * @param widget The {@link SymbolWidget} whose size must be computed.
+//     * @return A not {@code null} maximum dimension of the given {@code widget}.
+//     */
+//    public static Dimension2D computeMaximumSize ( final SymbolWidget widget ) {
+//
+//        Double[] max_size = new Double[] { 0.0, 0.0 };
+//
+//        widget.propSymbols().getValue().stream().forEach(s -> {
+//
+//            final String imageFile = s.getValue();
+//
+//            try {
+//
+//                final SymbolRepresentation representation = widget.getUserData(Widget.USER_DATA_REPRESENTATION);
+//                final ImageContent ic = representation.imagesMap.containsKey(imageFile)
+//                                      ? representation.imagesMap.get(imageFile)
+//                                      : representation.createImageContent(imageFile);
+//
+//                if ( max_size[0] < ic.getOriginalWidth() ) {
+//                    max_size[0] = ic.getOriginalWidth();
+//                }
+//                if ( max_size[1] < ic.getOriginalHeight() ) {
+//                    max_size[1] = ic.getOriginalHeight();
+//                }
+//
+//            } catch ( Exception ex ) {
+//                //  The following message has proven to be annoying and not useful.
+//                //logger.log(Level.WARNING, "Cannot obtain image size for {0} [{1}].", new Object[] { imageFile, ex.getMessage() });
+//            }
+//
+//        });
+//
+//        return new Dimension2D(max_size[0], max_size[1]);
+//
+//    }
+//
+//    public static String resolveImageFile ( SymbolWidget widget, String imageFileName ) {
+//
+//        try {
+//
+//            String expandedFileName = MacroHandler.replace(widget.getMacrosOrProperties(), imageFileName);
+//
+//            //  Resolve new image file relative to the source widget model (not 'top'!).
+//            //  Get the display model from the widget tied to this representation.
+//            final DisplayModel widgetModel = widget.getDisplayModel();
+//
+//            // Resolve the image path using the parent model file path.
+//            return ModelResourceUtil.resolveResource(widgetModel, expandedFileName);
+//
+//        } catch ( Exception ex ) {
+//
+//            logger.log(Level.WARNING, "Failure resolving image path: {0} [{1}].", new Object[] { imageFileName, ex.getMessage() });
+//
+//            return null;
+//
+//        }
+//
+//    }
+//
+//    private static boolean resourceExists ( String fileName ) {
+//
+//        try {
+//            ModelResourceUtil.openResourceStream(fileName);
+//        } catch ( Exception ex ) {
+//            return false;
+//        }
+//
+//        return true;
+//
+//    }
+//
+//    @Override
+//    public void dispose ( ) {
+//        super.dispose();
+//
+//        logger.info("**** Symbol widget disposed");
+//
+//    }
+//
+//    private void contentChanged ( final WidgetProperty<?> property, final Object oldValue, final Object newValue ) {
+//        dirtyContent.mark();
+//        toolkit.scheduleUpdate(this);
+//    }
+//
+//
+//    private ImageContent createImageContent ( String fileName ) {
+//        return new ImageContent(fileName);
+//    }
+//
+//    private Image getDefaultSymbol() {
+//
+//        if ( defaultSymbol == null ) {
+//            synchronized ( SymbolRepresentation.class ) {
+//                if ( defaultSymbol == null ) {
+//                    defaultSymbol = loadDefaultSymbol();
+//                }
+//            }
+//        }
+//
+//        return defaultSymbol;
+//
+//    }
+//
+//    private <T> T  getDisplayable( Predicate<ImageContent> predicate, Function<ImageContent, T> getter, T defaultDisplayable ) {
+//
+//        int index = getImageIndex();
+//
+//        if ( index >= 0 && index < imagesList.size() ) {
+//
+//            ImageContent imageContent = imagesList.get(index);
+//
+//            if ( predicate.test(imageContent) ) {
+//                return getter.apply(imageContent);
+//            } else {
+//                return defaultDisplayable;
+//            }
+//
+//        } else {
+//            return defaultDisplayable;
+//        }
+//
+//    }
+//
+//    private void imageChanged ( final WidgetProperty<String> property, final String oldValue, final String newValue ) {
+//        EXECUTOR.execute(() -> {
+//
+//            updateSymbols();
+//
+//            dirtyContent.mark();
+//            toolkit.scheduleUpdate(this);
+//
+//        });
+//    }
+//
+//    private void imagesChanged ( final WidgetProperty<List<WidgetProperty<String>>> property, final List<WidgetProperty<String>> oldValue, final List<WidgetProperty<String>> newValue ) {
+//        EXECUTOR.execute(() -> {
+//
+//            updateSymbols();
+//
+//            if ( oldValue != null ) {
+//                oldValue.stream().forEach(p -> p.removePropertyListener(imagePropertyListener));
+//            }
+//
+//            if ( newValue != null ) {
+//                newValue.stream().forEach(p -> p.addPropertyListener(imagePropertyListener));
+//            }
+//
+//            dirtyContent.mark();
+//            toolkit.scheduleUpdate(this);
+//
+//        });
+//    }
+//
+//    private void initialIndexChanged ( final WidgetProperty<?> property, final Object oldValue, final Object newValue ) {
+//        dirtyIndex.mark();
+//        toolkit.scheduleUpdate(this);
+//    }
+//
+//    private Image loadDefaultSymbol() {
+//
+//        String imageFileName = resolveImageFile(model_widget, SymbolWidget.DEFAULT_SYMBOL);
+//
+//        try {
+//            //  Open the image from the stream created from the resource file.
+//            return new Image(ModelResourceUtil.openResourceStream(imageFileName));
+//        } catch ( Exception ex ) {
+//            logger.log(Level.WARNING, "Failure loading image: {0} [{1}].", new Object[] { SymbolWidget.DEFAULT_SYMBOL, ex.getMessage() });
+//        }
+//
+//        return null;
+//
+//    }
+//
+//    /**
+//     * Fix the file names imported from BOY.
+//     */
+//    private void updateImportedSymbols ( ) {
+//
+//        try {
+//
+//            ArrayWidgetProperty<WidgetProperty<String>> propSymbols = model_widget.propSymbols();
+//            List<String> fileNames = new ArrayList<>(2);
+//
+//            switch ( model_widget.getImportedFrom() ) {
+//                case "org.csstudio.opibuilder.widgets.ImageBoolIndicator":
+//                    return;
+//                case "org.csstudio.opibuilder.widgets.symbol.bool.BoolMonitorWidget": {
+//
+//                        String imageFileName = propSymbols.getElement(0).getValue();
+//                        int dotIndex = imageFileName.lastIndexOf('.');
+//                        String onImageFileName = imageFileName.substring(0, dotIndex) + " On" + imageFileName.substring(dotIndex);
+//                        String offImageFileName = imageFileName.substring(0, dotIndex) + " Off" + imageFileName.substring(dotIndex);
+//
+//                        if ( resourceExists(resolveImageFile(model_widget, onImageFileName)) ) {
+//                            fileNames.add(onImageFileName);
+//                        } else {
+//                            fileNames.add(imageFileName);
+//                        }
+//
+//                        if ( resourceExists(resolveImageFile(model_widget, offImageFileName)) ) {
+//                            fileNames.add(offImageFileName);
+//                        } else {
+//                            fileNames.add(imageFileName);
+//                        }
+//
+//                    }
+//                    break;
+//                case "org.csstudio.opibuilder.widgets.symbol.multistate.MultistateMonitorWidget": {
+//
+//                        String imageFileName = propSymbols.getElement(0).getValue();
+//                        int dotIndex = imageFileName.lastIndexOf('.');
+//                        int spaceIndex = imageFileName.lastIndexOf(' ');
+//
+//                        try {
+//                            model_widget.propInitialIndex().setValue(Integer.parseInt(imageFileName.substring(1 + spaceIndex, dotIndex)));
+//                        } catch ( NumberFormatException nfex ) {
+//                            logger.log(Level.WARNING, "Imported image file doesn't contain state value [{0}].", imageFileName);
+//                        }
+//
+//                        int index = 0;
+//
+//                        while ( true ) {
+//
+//                            String nthImageFileName = MessageFormat.format(
+//                                "{0} {1,number,#########0}{2}",
+//                                imageFileName.substring(0, spaceIndex),
+//                                index,
+//                                imageFileName.substring(dotIndex)
+//                            );
+//
+//                            if ( resourceExists(resolveImageFile(model_widget, nthImageFileName)) ) {
+//                                fileNames.add(nthImageFileName);
+//                            } else {
+//                                break;
+//                            }
+//
+//                            index++;
+//
+//                        }
+//
+//                    }
+//                    break;
+//                default:
+//                    logger.log(Level.WARNING, "Invalid imported type [{0}].", model_widget.getImportedFrom());
+//                    return;
+//            }
+//
+//            for ( int i = 0; i < fileNames.size(); i++ ) {
+//                model_widget.addOrReplaceSymbol(i, fileNames.get(i));
+//            }
+//
+//        } finally {
+//            model_widget.clearImportedFrom();
+//        }
+//
+//    }
+//
+//    private synchronized void updateSymbols ( ) {
+//
+//        updatingSymbols.lock();
+//
+//        try {
+//
+//            int oldIndex = getImageIndex();
+//
+//            try {
+//
+//                ArrayWidgetProperty<WidgetProperty<String>> propSymbols = model_widget.propSymbols();
+//                List<WidgetProperty<String>> fileNames = propSymbols.getValue();
+//
+//                if ( model_widget.getImportedFrom() != null ) {
+//                    updateImportedSymbols();
+//                }
+//
+//                if ( fileNames == null ) {
+//                    logger.log(Level.WARNING, "Empty list of file names.");
+//                } else {
+//
+//                    imagesList.clear();
+//
+//                    fileNames.stream().forEach(f -> {
+//
+//                        String fileName = f.getValue();
+//                        ImageContent imageContent = imagesMap.get(fileName);
+//
+//                        if ( imageContent == null ) {
+//
+//                            imageContent = createImageContent(fileName);
+//
+//                            if ( imageContent.isValid() ) {
+//                                imagesMap.put(fileName, imageContent);
+//                            }
+//
+//                        }
+//
+//                        if ( imageContent.isValid() ) {
+//                            imagesList.add(imageContent);
+//                        }
+//
+//                    });
+//
+//                    Set<String> toBeRemoved = imagesMap.keySet().stream().filter(f -> !imagesList.contains(imagesMap.get(f))).collect(Collectors.toSet());
+//
+//                    toBeRemoved.stream().forEach(f -> imagesMap.remove(f));
+//
+//                }
+//
+//            } finally {
+//
+//                int newImageIndex = Math.min(Math.max(getImageIndex(), 0), imagesList.size() - 1);
+//
+//                maxSize = computeMaximumSize(model_widget);
+//
+//                if ( oldIndex == newImageIndex && oldIndex >= 0 ) {
+//
+//                    ImageContent imageContent = imagesList.get(getImageIndex());
+//
+//                    if ( imageContent.isSVG() || ( imageContent.isImage() && imagePane.getCenter() != imageView ) ) {
+//                        Platform.runLater(() -> triggerContentUpdate());
+//                    } else if ( imageContent.isImage() ) {
+//                        Platform.runLater(() -> triggerImageUpdate());
+//                    }
+//
+//                } else if ( oldIndex != newImageIndex ) {
+//                    setImageIndex(newImageIndex);
+//                }
+//
+//                dirtyGeometry.mark();
+//                dirtyValue.mark();
+//                toolkit.scheduleUpdate(this);
+//
+//            }
+//
+//        } finally {
+//            updatingSymbols.unlock();
+//        }
+//
+//    }
+//
+//    private class ImageContent {
+//
+//        private Image image;
+//        private double originalHeight;
+//        private double originalWidth;
+//        private SVG svg;
+//
+//        ImageContent ( String fileName ) {
+//
+//            boolean loadFailed = true;
+//            String imageFileName = resolveImageFile(model_widget, fileName);
+//
+//            if ( imageFileName != null ) {
+//                if ( imageFileName.toLowerCase().endsWith(".svg") ) {
+//                    try {
+//
+//                        // Open the image from the stream created from the resource file
+//                        svg = SVG.load(ModelResourceUtil.openResourceStream(imageFileName));
+//
+//                        Bounds bounds = svg.getLayoutBounds();
+//
+//                        originalWidth = bounds.getWidth();
+//                        originalHeight = bounds.getHeight();
+//                        image = null;
+//                        loadFailed = false;
+//
+//                    } catch ( Exception ex ) {
+//                        logger.log(Level.WARNING, "Failure loading SVG image file: ({0}) {1} [{2}].", new Object[] { fileName, imageFileName, ex.getMessage() });
+//                    }
+//                } else {
+//                    try {
+//                        //  Open the image from the stream created from the resource file.
+//                        image = new Image(ModelResourceUtil.openResourceStream(imageFileName));
+//                        originalWidth = image.getWidth();
+//                        originalHeight = image.getHeight();
+//                        svg = null;
+//                        loadFailed = false;
+//                    } catch ( Exception ex ) {
+//                        logger.log(Level.WARNING, "Failure loading image: ({0}) {1} [{2}].", new Object[] { fileName, imageFileName, ex.getMessage() });
+//                    }
+//                }
+//            }
+//
+//            if ( loadFailed ) {
+//
+//                imageFileName = resolveImageFile(model_widget, SymbolWidget.DEFAULT_SYMBOL);
+//
+//                try {
+//                    //  Open the image from the stream created from the resource file.
+//                    image = getDefaultSymbol();
+//                    originalWidth = image.getWidth();
+//                    originalHeight = image.getHeight();
+//                    svg = null;
+//                } catch ( Exception ex ) {
+//                    logger.log(Level.WARNING, "Failure loading image: ({0}) {1} [{2}].", new Object[] { fileName, imageFileName, ex.getMessage() });
+//                    image = null;
+//                    svg = null;
+//                    originalWidth = Double.NaN;
+//                    originalHeight = Double.NaN;
+//                }
+//
+//            }
+//
+//        }
+//
+//        Image getImage() {
+//            return image;
+//        }
+//
+//        double getOriginalHeight() {
+//            return originalHeight;
+//        }
+//
+//        double getOriginalRatio() {
+//            return originalWidth / originalHeight;
+//        }
+//
+//        double getOriginalWidth() {
+//            return originalWidth;
+//        }
+//
+//        SVG getSVG() {
+//            return svg;
+//        }
+//
+//        boolean isImage() {
+//            return ( image != null );
+//        }
+//
+//        boolean isSVG() {
+//            return ( svg != null );
+//        }
+//
+//        boolean isValid() {
+//            return ( isImage() || isSVG() );
+//        }
+//
+//    }
 
 }

--- a/org.csstudio.javafx/META-INF/MANIFEST.MF
+++ b/org.csstudio.javafx/META-INF/MANIFEST.MF
@@ -14,5 +14,6 @@ Require-Bundle: org.csstudio.display.builder.util;bundle-version="1.0.0",
  org.fxmisc.flowless,
  org.fxmisc.richtext.fx,
  org.fxmisc.undo.fx,
- org.fxmisc.wellbehaved.fx
+ org.fxmisc.wellbehaved.fx,
+ org.apache.commons.collections4
 Bundle-ActivationPolicy: lazy

--- a/org.csstudio.javafx/src/org/csstudio/javafx/ImageCache.java
+++ b/org.csstudio.javafx/src/org/csstudio/javafx/ImageCache.java
@@ -1,0 +1,90 @@
+/**
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * Copyright (C) 2016 European Spallation Source ERIC.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.csstudio.javafx;
+
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength;
+import org.apache.commons.collections4.map.ReferenceMap;
+
+import javafx.scene.image.Image;
+
+
+/**
+ * At ESS a lot of OPIs are based on some schematics, using a great number
+ * of symbol widgets often reusing the same images.
+ * <p>
+ * This class will allow caching of images using their resolved filename as key.
+ * <p/>
+ * <p>
+ * Current implementation uses a {@link ReferenceMap} of soft pointers for both
+ * the key and the value (an {@link Image}). This will allow for the garbage
+ * collector to reclaim the memory of unreferenced images on critically low
+ * memory
+ * situations.
+ * </p>
+ * <p>
+ * A better implementation will use a real cache library (e.g.
+ * <a href="https://cache2k.org">cache2k</a>) with proper policies.
+ * </p>
+ *
+ * @author claudiorosati, European Spallation Source ERIC
+ * @version 1.0.0 17 Oct 2018
+ */
+public class ImageCache {
+
+    private static final Map<String, Image> CACHE = Collections.synchronizedMap(new ReferenceMap<>(ReferenceStrength.SOFT, ReferenceStrength.SOFT));
+
+    /**
+     * @return The number of entries before the cache is cleared.
+     */
+    public static int clear ( ) {
+
+        int entries = size();
+
+        CACHE.clear();
+
+        return entries;
+
+    }
+
+    /**
+     * @param key The unique identifier of the cached image, usually its
+     *            resolved filename.
+     * @return The cached {@link Image} instance or {@code null}.
+     */
+    public static Image get ( String key ) {
+        return CACHE.get(key);
+    }
+
+    /**
+     * @param key The unique identifier of the cached image, usually its
+     *            resolved filename.
+     * @param value The {@link Image} to be cached.
+     * @return The previously {@link Image} associated with the given
+     *         {@code key}, or {@code null}.
+     */
+    public static Image put ( String key, Image value ) {
+        return CACHE.put(key, value);
+    }
+
+    /**
+     * @return The current cache size, i.e. the number of elements stored in the
+     *         cache.
+     */
+    public static int size ( ) {
+        return CACHE.size();
+    }
+
+    private ImageCache ( ) {
+    }
+
+}


### PR DESCRIPTION
Symbol widget code was in time upgraded to add support for SVG and other features (mostly to loading images in multi-thread). This created a code wit some random problems loading problems and weird display of SVG image.

I've rewritten completely the code, now being more reliable and much faster. All SVG problems disappeared too (now SVGs a transformed into Images through the Node.snapshot(...) method).

I've update also the Picture widget for the SVG related code.

This patch closes 6 tickets at ESS regarding symbols loading and badly displayed SVGs.