### PR TITLE
Fixed wrong position of labels and missing foreground.

### DIFF
--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/ByteMonitorWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/ByteMonitorWidget.java
@@ -118,8 +118,15 @@ public class ByteMonitorWidget extends PVWidget
                     labels.add(XMLUtil.getString(e));
                 if (labels.size() > 0)
                 {
+                    Optional<Boolean> reverse = XMLUtil.getChildBoolean(xml, "bitReverse");
                     Optional<WidgetColor> foregroundColor = XMLUtil.getChildColor(xml, "foreground_color");
-                    addLabels((ByteMonitorWidget) widget, xml, labels, foregroundColor.orElse(WidgetColorService.getColor(NamedWidgetColors.TEXT)));
+                    addLabels(
+                        (ByteMonitorWidget) widget,
+                        xml,
+                        labels,
+                        reverse.orElse(Boolean.FALSE),
+                        foregroundColor.orElse(WidgetColorService.getColor(NamedWidgetColors.TEXT))
+                    );
                 }
             }
 
@@ -127,7 +134,7 @@ public class ByteMonitorWidget extends PVWidget
         }
 
         // Add LabelWidget XML for legacy labels
-        private void addLabels(final ByteMonitorWidget widget, final Element xml, final List<String> labels, final WidgetColor foreground)
+        private void addLabels(final ByteMonitorWidget widget, final Element xml, final List<String> labels, final boolean reverse, final WidgetColor foreground)
         {
             double x = widget.propX().getValue();
             double y = widget.propY().getValue();
@@ -140,14 +147,14 @@ public class ByteMonitorWidget extends PVWidget
             {
                 dy = 0;
                 dx = w / n;
-                x = x + w - dx;
+                x = reverse ? x : x + w - dx;
                 w = dx;
             }
             else
             {
                 dx = 0;
                 dy = h / n;
-                y = y + h - dy;
+                y = reverse ? y : y + h - dy;
                 h = dy;
             }
             final Node parent = xml.getParentNode();
@@ -159,8 +166,8 @@ public class ByteMonitorWidget extends PVWidget
                     parent.insertBefore(label, next);
                 else
                     parent.appendChild(label);
-                x -= dx;
-                y -= dy;
+                x += reverse ? dx : -dx;
+                y += reverse ? dy : -dy;
             }
         }
 

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/ByteMonitorWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/ByteMonitorWidget.java
@@ -30,6 +30,8 @@ import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.WidgetPropertyCategory;
 import org.csstudio.display.builder.model.WidgetPropertyDescriptor;
 import org.csstudio.display.builder.model.persist.ModelReader;
+import org.csstudio.display.builder.model.persist.NamedWidgetColors;
+import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.persist.XMLTags;
 import org.csstudio.display.builder.model.persist.XMLUtil;
 import org.csstudio.display.builder.model.properties.HorizontalAlignment;
@@ -115,14 +117,17 @@ public class ByteMonitorWidget extends PVWidget
                 for (Element e : XMLUtil.getChildElements(el, "s"))
                     labels.add(XMLUtil.getString(e));
                 if (labels.size() > 0)
-                    addLabels((ByteMonitorWidget) widget, xml, labels);
+                {
+                    Optional<WidgetColor> foregroundColor = XMLUtil.getChildColor(xml, "foreground_color");
+                    addLabels((ByteMonitorWidget) widget, xml, labels, foregroundColor.orElse(WidgetColorService.getColor(NamedWidgetColors.TEXT)));
+                }
             }
 
             return true;
         }
 
         // Add LabelWidget XML for legacy labels
-        private void addLabels(final ByteMonitorWidget widget, final Element xml, final List<String> labels)
+        private void addLabels(final ByteMonitorWidget widget, final Element xml, final List<String> labels, final WidgetColor foreground)
         {
             double x = widget.propX().getValue();
             double y = widget.propY().getValue();
@@ -135,30 +140,32 @@ public class ByteMonitorWidget extends PVWidget
             {
                 dy = 0;
                 dx = w / n;
+                x = x + w - dx;
                 w = dx;
             }
             else
             {
                 dx = 0;
                 dy = h / n;
+                y = y + h - dy;
                 h = dy;
             }
             final Node parent = xml.getParentNode();
             final Node next = xml.getNextSibling();
             for (String text : labels)
             {
-                final Element label = createLabelWidget(xml, (int)x, (int)y, (int)w, (int)h, text, horiz);
+                final Element label = createLabelWidget(xml, (int)x, (int)y, (int)w, (int)h, text, horiz, foreground);
                 if (next != null)
                     parent.insertBefore(label, next);
                 else
                     parent.appendChild(label);
-                x += dx;
-                y += dy;
+                x -= dx;
+                y -= dy;
             }
         }
 
         // Create LabelWidget XML
-        private Element createLabelWidget(final Element xml, final int x, final int y, final int w, final int h, final String text, final boolean horiz)
+        private Element createLabelWidget(final Element xml, final int x, final int y, final int w, final int h, final String text, final boolean horiz, final WidgetColor foreground)
         {
             System.out.println(text);
             final Document doc = xml.getOwnerDocument();
@@ -195,6 +202,14 @@ public class ByteMonitorWidget extends PVWidget
 
             el = doc.createElement(propVerticalAlignment.getName());
             el.appendChild(doc.createTextNode(Integer.toString(VerticalAlignment.MIDDLE.ordinal())));
+            label.appendChild(el);
+
+            final Element fel = doc.createElement(XMLTags.COLOR);
+            fel.setAttribute("red", String.valueOf(foreground.getRed()));
+            fel.setAttribute("green", String.valueOf(foreground.getGreen()));
+            fel.setAttribute("blue", String.valueOf(foreground.getBlue()));
+            el = doc.createElement("foreground_color");
+            el.appendChild(fel);
             label.appendChild(el);
 
             if (horiz)


### PR DESCRIPTION
Importing is ByteMonitor with labels doesn't work as expected. Here the BOY example:

![screenshot 2018-10-30 at 13 59 11](https://user-images.githubusercontent.com/10833922/47722223-2ae6d500-dc52-11e8-97c8-82df779cafcf.png)

and here the imported one:

![screenshot 2018-10-30 at 14 00 57](https://user-images.githubusercontent.com/10833922/47722233-32a67980-dc52-11e8-8f0b-7d8b49b934fe.png)

This is the situation after the fix:

![screenshot 2018-10-30 at 14 40 26](https://user-images.githubusercontent.com/10833922/47722242-3c2fe180-dc52-11e8-9c2d-09f535d1a162.png)
