### PR TITLE
CSSTUDIO-880: Tooltip not working in Ellipse, Arc, Polygon and Polyline

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ArcRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ArcRepresentation.java
@@ -43,6 +43,10 @@ public class ArcRepresentation extends JFXBaseRepresentation<Arc, ArcWidget>
     {
         // JFX Arc is based on center, not top-left corner,
         // so can't use the default from super.registerListeners();
+        // ==> Tooltip must be attached explicitly.
+        if (! toolkit.isEditMode())
+            attachTooltip();
+        // ==> Visibility and position nust be handled explicitly.
         model_widget.propVisible().addUntypedPropertyListener(this::positionChanged);
         model_widget.propX().addUntypedPropertyListener(this::positionChanged);
         model_widget.propY().addUntypedPropertyListener(this::positionChanged);

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EllipseRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EllipseRepresentation.java
@@ -38,6 +38,10 @@ public class EllipseRepresentation extends JFXBaseRepresentation<Ellipse, Ellips
     {
         // JFX Ellipse is based on center, not top-left corner,
         // so can't use the default from super.registerListeners();
+        // ==> Tooltip must be attached explicitly.
+        if (! toolkit.isEditMode())
+            attachTooltip();
+        // ==> Visibility and position nust be handled explicitly.
         model_widget.propVisible().addUntypedPropertyListener(this::positionChanged);
         model_widget.propX().addUntypedPropertyListener(this::positionChanged);
         model_widget.propY().addUntypedPropertyListener(this::positionChanged);

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PolygonRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PolygonRepresentation.java
@@ -36,6 +36,10 @@ public class PolygonRepresentation extends JFXBaseRepresentation<Polygon, Polygo
     protected void registerListeners()
     {
         // Polygon can't use the default x/y handling from super.registerListeners();
+        // ==> Tooltip must be attached explicitly.
+        if (! toolkit.isEditMode())
+            attachTooltip();
+        // ==> Visibility and position nust be handled explicitly.
         model_widget.propVisible().addUntypedPropertyListener(this::displayChanged);
         model_widget.propX().addUntypedPropertyListener(this::displayChanged);
         model_widget.propY().addUntypedPropertyListener(this::displayChanged);

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PolylineRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PolylineRepresentation.java
@@ -79,6 +79,10 @@ public class PolylineRepresentation extends JFXBaseRepresentation<Group, Polylin
     protected void registerListeners()
     {
         // Polyline can't use the default x/y handling from super.registerListeners();
+        // ==> Tooltip must be attached explicitly.
+        if (! toolkit.isEditMode())
+            attachTooltip();
+        // ==> Visibility and position nust be handled explicitly.
         model_widget.propVisible().addUntypedPropertyListener(this::displayChanged);
         model_widget.propX().addUntypedPropertyListener(this::displayChanged);
         model_widget.propY().addUntypedPropertyListener(this::displayChanged);


### PR DESCRIPTION
Calling missing attachTooltip() for widget not invoking super.registerListeners().