### PR TITLE
Added "foreground" property to CheckBox and Image.

### DIFF
--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/CheckBoxWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/CheckBoxWidget.java
@@ -14,6 +14,7 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propConfirmMessage;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propEnabled;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFont;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propPassword;
 
 import java.util.Arrays;
@@ -26,9 +27,12 @@ import org.csstudio.display.builder.model.WidgetDescriptor;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.WidgetPropertyCategory;
 import org.csstudio.display.builder.model.WidgetPropertyDescriptor;
+import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.NamedWidgetFonts;
+import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.persist.WidgetFontService;
 import org.csstudio.display.builder.model.properties.ConfirmDialog;
+import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.properties.WidgetFont;
 
 @SuppressWarnings("nls")
@@ -63,6 +67,7 @@ public class CheckBoxWidget extends WritablePVWidget
     private volatile WidgetProperty<Boolean> enabled;
     private volatile WidgetProperty<Integer> bit;
     private volatile WidgetProperty<String> label;
+    private volatile WidgetProperty<WidgetColor> foreground;
     private volatile WidgetProperty<WidgetFont> font;
     private volatile WidgetProperty<Boolean> auto_size;
     private volatile WidgetProperty<ConfirmDialog> confirm_dialog;
@@ -76,6 +81,7 @@ public class CheckBoxWidget extends WritablePVWidget
         properties.add(bit = propBit.createProperty(this, 0));
         properties.add(label = propLabel.createProperty(this, Messages.Checkbox_Label));
         properties.add(font = propFont.createProperty(this, WidgetFontService.get(NamedWidgetFonts.DEFAULT)));
+        properties.add(foreground = propForegroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.TEXT)));
         properties.add(auto_size = propAutoSize.createProperty(this, false));
         properties.add(enabled = propEnabled.createProperty(this, true));
         properties.add(confirm_dialog = propConfirmDialogOptions.createProperty(this, ConfirmDialog.NONE));
@@ -104,6 +110,12 @@ public class CheckBoxWidget extends WritablePVWidget
     public WidgetProperty<WidgetFont> propFont()
     {
         return font;
+    }
+
+    /** @return 'foreground_color' property */
+    public WidgetProperty<WidgetColor> propForegroundColor()
+    {
+        return foreground;
     }
 
     /** @return 'auto_size' property */

--- a/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/plots/ImageWidget.java
+++ b/org.csstudio.display.builder.model/src/org/csstudio/display/builder/model/widgets/plots/ImageWidget.java
@@ -10,6 +10,7 @@ package org.csstudio.display.builder.model.widgets.plots;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propBackgroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propFile;
+import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propForegroundColor;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propInteractive;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMaximum;
 import static org.csstudio.display.builder.model.properties.CommonWidgetProperties.propMinimum;
@@ -357,6 +358,7 @@ public class ImageWidget extends PVWidget
     }
 
     private volatile WidgetProperty<WidgetColor> background;
+    private volatile WidgetProperty<WidgetColor> foreground;
     private volatile WidgetProperty<Boolean> show_toolbar;
     private volatile WidgetProperty<ColorMap> data_colormap;
     private volatile ColorBarProperty color_bar;
@@ -385,6 +387,7 @@ public class ImageWidget extends PVWidget
     {
         super.defineProperties(properties);
         properties.add(background = propBackgroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.BACKGROUND)));
+        properties.add(foreground = propForegroundColor.createProperty(this, WidgetColorService.getColor(NamedWidgetColors.TEXT)));
         properties.add(show_toolbar = propToolbar.createProperty(this,false));
         properties.add(data_colormap = propDataColormap.createProperty(this, PredefinedColorMaps.VIRIDIS));
         properties.add(color_bar = new ColorBarProperty(this));
@@ -426,6 +429,12 @@ public class ImageWidget extends PVWidget
     public WidgetProperty<WidgetColor> propBackground()
     {
         return background;
+    }
+
+    /** @return 'foreground_color' property */
+    public WidgetProperty<WidgetColor> propForegroundColor()
+    {
+        return foreground;
     }
 
     /** @return 'show_toolbar' property */

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/CheckBoxRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/CheckBoxRepresentation.java
@@ -118,6 +118,7 @@ public class CheckBoxRepresentation extends RegionBaseRepresentation<CheckBox, C
 
         labelChanged(model_widget.propLabel(), null, model_widget.propLabel().getValue());
         model_widget.propLabel().addPropertyListener(this::labelChanged);
+        model_widget.propForegroundColor().addUntypedPropertyListener(this::styleChanged);
         model_widget.propFont().addUntypedPropertyListener(this::styleChanged);
         model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
         model_widget.runtimePropPVWritable().addUntypedPropertyListener(this::styleChanged);
@@ -185,6 +186,7 @@ public class CheckBoxRepresentation extends RegionBaseRepresentation<CheckBox, C
         {
             jfx_node.setText(label);
             jfx_node.setFont(JFXUtil.convert(model_widget.propFont().getValue()));
+            jfx_node.setTextFill(JFXUtil.convert(model_widget.propForegroundColor().getValue()));
 
             // Don't disable the widget, because that would also remove the
             // context menu etc.

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
@@ -47,6 +47,7 @@ import javafx.application.Platform;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.image.Image;
 import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
 
 /** Creates JavaFX item for model widget
  *  @author Kay Kasemir
@@ -247,6 +248,7 @@ public class ImageRepresentation extends RegionBaseRepresentation<Pane, ImageWid
 
         model_widget.propToolbar().addUntypedPropertyListener(this::configChanged);
         model_widget.propBackground().addUntypedPropertyListener(this::configChanged);
+        model_widget.propForegroundColor().addUntypedPropertyListener(this::configChanged);
         model_widget.propColorbar().visible().addUntypedPropertyListener(this::configChanged);
         model_widget.propColorbar().barSize().addUntypedPropertyListener(this::configChanged);
         model_widget.propColorbar().scaleFont().addUntypedPropertyListener(this::configChanged);
@@ -324,12 +326,17 @@ public class ImageRepresentation extends RegionBaseRepresentation<Pane, ImageWid
      */
     private void configChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
     {
+        Color fg = JFXUtil.convert(model_widget.propForegroundColor().getValue());
+
         image_plot.showToolbar(model_widget.propToolbar().getValue());
         image_plot.setBackground(JFXUtil.convert(model_widget.propBackground().getValue()));
         image_plot.showColorMap(model_widget.propColorbar().visible().getValue());
         image_plot.setColorMapSize(model_widget.propColorbar().barSize().getValue());
         image_plot.setColorMapFont(JFXUtil.convert(model_widget.propColorbar().scaleFont().getValue()));
+        image_plot.setColorMapForeground(fg);
         image_plot.showCrosshair(model_widget.propCursorCrosshair().getValue());
+        image_plot.getXAxis().setColor(fg);
+        image_plot.getYAxis().setColor(fg);
 
         if (! changing_axis_range)
         {

--- a/org.csstudio.javafx.rtplot/src/org/csstudio/javafx/rtplot/RTImagePlot.java
+++ b/org.csstudio.javafx.rtplot/src/org/csstudio/javafx/rtplot/RTImagePlot.java
@@ -36,6 +36,7 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
@@ -405,6 +406,11 @@ public class RTImagePlot extends BorderPane
     public void setColorMapFont(final Font font)
     {
         plot.setColorMapFont(font);
+    }
+
+    /** @param foreground Color bar text color. */
+    public void setColorMapForeground(final Color foreground) {
+        plot.setColorMapForeground(foreground);
     }
 
     /** @param show Show crosshair, moved on click?

--- a/org.csstudio.javafx.rtplot/src/org/csstudio/javafx/rtplot/internal/ImagePlot.java
+++ b/org.csstudio.javafx.rtplot/src/org/csstudio/javafx/rtplot/internal/ImagePlot.java
@@ -296,6 +296,13 @@ public class ImagePlot extends PlotCanvasBase
         requestLayout();
     }
 
+    /** @param foreground Color bar text color. */
+    public void setColorMapForeground(final javafx.scene.paint.Color foreground) {
+        colorbar_axis.setColor(foreground);
+// CR: Not sure about it.
+        requestLayout();
+    }
+
     /** @param show Show crosshair, moved on click?
      *              Or update cursor listener with each mouse move,
      *              not showing a persistent crosshair?


### PR DESCRIPTION
CheckBox and Image widgets always drawn text in black, and when the background is dark it is difficult if not impossible to read. This PR fixes it.

@kasemir 
I've put a comment for you starting with `// CR:` because I'm not sure if the following statement is needed or not.

<img width="597" alt="screenshot 2018-11-26 at 14 25 40" src="https://user-images.githubusercontent.com/10833922/49017164-6eb4f780-f188-11e8-9031-ccde3229814d.png">
