### PR TITLE
Update embedded content when a macro changed

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
@@ -124,6 +124,7 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
 
         model_widget.propFile().addUntypedPropertyListener(this::fileChanged);
         model_widget.propGroupName().addUntypedPropertyListener(this::fileChanged);
+        model_widget.propMacros().addUntypedPropertyListener(this::fileChanged);
 
         model_widget.propTransparent().addUntypedPropertyListener(this::backgroundChanged);
         fileChanged(null, null, null);


### PR DESCRIPTION
Updating or defining a macro in an Embedded Container will not update the content (reload the file with the new set of macro values) neither in editor, nor in runtime.

I've added a missing listener.