### PR TITLE
Don't use image cache in edit mode.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PictureRepresentation.java
@@ -163,6 +163,10 @@ public class PictureRepresentation extends JFXBaseRepresentation<Group, PictureW
 
         if ( !load_failed ) {
 
+            if ( toolkit.isEditMode() ) {
+                ImageCache.remove(img_path);
+            }
+
             img_loaded = ImageCache.get(img_path);
 
             if ( img_loaded == null ) {

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -707,6 +707,10 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
 
             if ( imageFileName != null ) {
 
+                if ( toolkit.isEditMode() ) {
+                    ImageCache.remove(imageFileName);
+                }
+
                 image = ImageCache.get(imageFileName);
 
                 if ( image != null ) {

--- a/org.csstudio.javafx/src/org/csstudio/javafx/ImageCache.java
+++ b/org.csstudio.javafx/src/org/csstudio/javafx/ImageCache.java
@@ -77,6 +77,16 @@ public class ImageCache {
     }
 
     /**
+     * @param key The unique identifier of the cached image, usually its
+     *            resolved filename.
+     * @return The previously {@link Image} associated with the given
+     *         {@code key}, or {@code null}.
+     */
+    public static Image remove ( String key ) {
+        return CACHE.remove(key);
+    }
+
+    /**
      * @return The current cache size, i.e. the number of elements stored in the
      *         cache.
      */


### PR DESCRIPTION
Picture and Symbol widgets use an image cache to speed up (re)loading of OPI using the same image.

In edit mode, if you assign an image to a Picture widget and then update the image itself, reloading the OPI doesn't work because the Picture widget is now using the cached image.

I've fixed this problem removing the images from the cache when loading a Picture and Symbol widgets.