### PR TITLE
NPE when dragging widgets inside Groups, Tabs or Arrays.

### DIFF
--- a/org.csstudio.display.builder.rcp/src/org/csstudio/display/builder/rcp/widgets/FileSelectorRepresentation.java
+++ b/org.csstudio.display.builder.rcp/src/org/csstudio/display/builder/rcp/widgets/FileSelectorRepresentation.java
@@ -14,6 +14,7 @@ import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.util.ModelResourceUtil;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.rcp.Messages;
@@ -54,6 +55,7 @@ public class FileSelectorRepresentation extends JFXBaseRepresentation<Button, Fi
         open_file_icon = icon;
     }
     private final DirtyFlag dirty_size = new DirtyFlag();
+    private final WidgetPropertyListener<Integer> sizeChangedListener = this::sizeChanged;
 
     @Override
     protected Button createJFXNode() throws Exception
@@ -73,8 +75,16 @@ public class FileSelectorRepresentation extends JFXBaseRepresentation<Button, Fi
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addPropertyListener(this::sizeChanged);
-        model_widget.propHeight().addPropertyListener(this::sizeChanged);
+        model_widget.propWidth().addPropertyListener(sizeChangedListener);
+        model_widget.propHeight().addPropertyListener(sizeChangedListener);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(sizeChangedListener);
+        model_widget.propHeight().removePropertyListener(sizeChangedListener);
+        super.unregisterListeners();
     }
 
     private void sizeChanged(final WidgetProperty<Integer> property, final Integer old_value, final Integer new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
@@ -14,7 +14,9 @@ import java.util.Optional;
 import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.macros.MacroHandler;
 import org.csstudio.display.builder.model.macros.MacroValueProvider;
 import org.csstudio.display.builder.model.properties.ActionInfo;
@@ -279,27 +281,51 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
         toolkit.fireAction(model_widget, action);
     }
 
+    private final UntypedWidgetPropertyListener buttonChangedListener = this::buttonChanged;
+    private final UntypedWidgetPropertyListener representationChangedListener = this::representationChanged;
+    private final WidgetPropertyListener<Boolean> enablementChangedListener = this::enablementChanged;
+
     @Override
     protected void registerListeners()
     {
         updateColors();
         super.registerListeners();
 
-        model_widget.propWidth().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propText().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propRotationStep().addUntypedPropertyListener(this::representationChanged);
+        model_widget.propWidth().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propText().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propRotationStep().addUntypedPropertyListener(representationChangedListener);
 
-        model_widget.propEnabled().addPropertyListener(this::enablementChanged);
-        model_widget.runtimePropPVWritable().addPropertyListener(this::enablementChanged);
+        model_widget.propEnabled().addPropertyListener(enablementChangedListener);
+        model_widget.runtimePropPVWritable().addPropertyListener(enablementChangedListener);
 
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::buttonChanged);
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::buttonChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::buttonChanged);
-        model_widget.propActions().addUntypedPropertyListener(this::buttonChanged);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(buttonChangedListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(buttonChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(buttonChangedListener);
+        model_widget.propActions().addUntypedPropertyListener(buttonChangedListener);
 
         enablementChanged(null, null, null);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(representationChangedListener);
+        model_widget.propHeight().removePropertyListener(representationChangedListener);
+        model_widget.propText().removePropertyListener(representationChangedListener);
+        model_widget.propFont().removePropertyListener(representationChangedListener);
+        model_widget.propRotationStep().removePropertyListener(representationChangedListener);
+
+        model_widget.propEnabled().removePropertyListener(enablementChangedListener);
+        model_widget.runtimePropPVWritable().removePropertyListener(enablementChangedListener);
+
+        model_widget.propBackgroundColor().removePropertyListener(buttonChangedListener);
+        model_widget.propForegroundColor().removePropertyListener(buttonChangedListener);
+        model_widget.propTransparent().removePropertyListener(buttonChangedListener);
+        model_widget.propActions().removePropertyListener(buttonChangedListener);
+
+        super.unregisterListeners();
     }
 
     @Override

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ActionButtonRepresentation.java
@@ -85,6 +85,10 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
 
     private Pane pane;
 
+    private final UntypedWidgetPropertyListener buttonChangedListener = this::buttonChanged;
+    private final UntypedWidgetPropertyListener representationChangedListener = this::representationChanged;
+    private final WidgetPropertyListener<Boolean> enablementChangedListener = this::enablementChanged;
+
     @Override
     protected boolean isFilteringEditModeClicks()
     {
@@ -280,10 +284,6 @@ public class ActionButtonRepresentation extends RegionBaseRepresentation<Pane, A
         }
         toolkit.fireAction(model_widget, action);
     }
-
-    private final UntypedWidgetPropertyListener buttonChangedListener = this::buttonChanged;
-    private final UntypedWidgetPropertyListener representationChangedListener = this::representationChanged;
-    private final WidgetPropertyListener<Boolean> enablementChangedListener = this::enablementChanged;
 
     @Override
     protected void registerListeners()

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ArcRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ArcRepresentation.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.representation.javafx.widgets;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.ArcWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -28,6 +29,8 @@ public class ArcRepresentation extends JFXBaseRepresentation<Arc, ArcWidget>
     private Double arc_size;
     private Double arc_start;
     private ArcType arc_type;
+    private final UntypedWidgetPropertyListener lookChangedListener = this::lookChanged;
+    private final UntypedWidgetPropertyListener positionChangedListener = this::positionChanged;
 
     @Override
     public Arc createJFXNode() throws Exception
@@ -47,18 +50,41 @@ public class ArcRepresentation extends JFXBaseRepresentation<Arc, ArcWidget>
         if (! toolkit.isEditMode())
             attachTooltip();
         // ==> Visibility and position nust be handled explicitly.
-        model_widget.propVisible().addUntypedPropertyListener(this::positionChanged);
-        model_widget.propX().addUntypedPropertyListener(this::positionChanged);
-        model_widget.propY().addUntypedPropertyListener(this::positionChanged);
-        model_widget.propWidth().addUntypedPropertyListener(this::positionChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::positionChanged);
+        model_widget.propVisible().addUntypedPropertyListener(positionChangedListener);
+        model_widget.propX().addUntypedPropertyListener(positionChangedListener);
+        model_widget.propY().addUntypedPropertyListener(positionChangedListener);
+        model_widget.propWidth().addUntypedPropertyListener(positionChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(positionChangedListener);
 
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLineColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLineWidth().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propArcSize().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propArcStart().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLineColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLineWidth().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propArcSize().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propArcStart().addUntypedPropertyListener(lookChangedListener);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        // JFX Arc is based on center, not top-left corner,
+        // so can't use the default from super.registerListeners();
+        // ==> Tooltip must be attached explicitly.
+        if (! toolkit.isEditMode())
+            detachTooltip();
+        // ==> Visibility and position nust be handled explicitly.
+        model_widget.propVisible().removePropertyListener(positionChangedListener);
+        model_widget.propX().removePropertyListener(positionChangedListener);
+        model_widget.propY().removePropertyListener(positionChangedListener);
+        model_widget.propWidth().removePropertyListener(positionChangedListener);
+        model_widget.propHeight().removePropertyListener(positionChangedListener);
+
+        model_widget.propBackgroundColor().removePropertyListener(lookChangedListener);
+        model_widget.propTransparent().removePropertyListener(lookChangedListener);
+        model_widget.propLineColor().removePropertyListener(lookChangedListener);
+        model_widget.propLineWidth().removePropertyListener(lookChangedListener);
+        model_widget.propArcSize().removePropertyListener(lookChangedListener);
+        model_widget.propArcStart().removePropertyListener(lookChangedListener);
     }
 
     private void positionChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseClockRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseClockRepresentation.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.BaseClockWidget;
 
@@ -30,6 +31,10 @@ public abstract class BaseClockRepresentation<W extends BaseClockWidget> extends
     private final DirtyFlag dirtyBehavior = new DirtyFlag();
     private final DirtyFlag dirtyGeometry = new DirtyFlag();
     private final DirtyFlag dirtyLook     = new DirtyFlag();
+
+    private final UntypedWidgetPropertyListener behaviorChangedListener = this::behaviorChanged;
+    private final UntypedWidgetPropertyListener geometryChangedListener = this::geometryChanged;
+    private final UntypedWidgetPropertyListener lookChangedListener     = this::lookChanged;
 
     @Override
     public void updateChanges ( ) {
@@ -209,20 +214,42 @@ public abstract class BaseClockRepresentation<W extends BaseClockWidget> extends
 
         super.registerListeners();
 
-        model_widget.propVisible().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propX().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propY().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propWidth().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::geometryChanged);
+        model_widget.propVisible().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propX().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propY().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propWidth().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(geometryChangedListener);
 
-        model_widget.propDateVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLocale().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propSecondVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propShadowsEnabled().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTitle().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTitleVisible().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propDateVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLocale().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propSecondVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propShadowsEnabled().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTitle().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTitleVisible().addUntypedPropertyListener(lookChangedListener);
 
-        model_widget.propRunning().addUntypedPropertyListener(this::behaviorChanged);
+        model_widget.propRunning().addUntypedPropertyListener(behaviorChangedListener);
+
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        model_widget.propVisible().removePropertyListener(geometryChangedListener);
+        model_widget.propX().removePropertyListener(geometryChangedListener);
+        model_widget.propY().removePropertyListener(geometryChangedListener);
+        model_widget.propWidth().removePropertyListener(geometryChangedListener);
+        model_widget.propHeight().removePropertyListener(geometryChangedListener);
+
+        model_widget.propDateVisible().removePropertyListener(lookChangedListener);
+        model_widget.propLocale().removePropertyListener(lookChangedListener);
+        model_widget.propSecondVisible().removePropertyListener(lookChangedListener);
+        model_widget.propShadowsEnabled().removePropertyListener(lookChangedListener);
+        model_widget.propTitle().removePropertyListener(lookChangedListener);
+        model_widget.propTitleVisible().removePropertyListener(lookChangedListener);
+
+        model_widget.propRunning().removePropertyListener(behaviorChangedListener);
+
+        super.unregisterListeners();
 
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseGaugeRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseGaugeRepresentation.java
@@ -14,7 +14,9 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.util.FormatOptionHandler;
@@ -54,6 +56,14 @@ public abstract class BaseGaugeRepresentation<W extends BaseGaugeWidget> extends
     private volatile double     max           = 100.0;
     private volatile double     min           = 0.0;
     private final AtomicBoolean updatingValue = new AtomicBoolean(false);
+
+    private final UntypedWidgetPropertyListener contentChangedListener  = this::contentChanged;
+    private final UntypedWidgetPropertyListener geometryChangedListener = this::geometryChanged;
+    private final UntypedWidgetPropertyListener limitsChangedListener   = this::limitsChanged;
+    private final UntypedWidgetPropertyListener lookChangedListener     = this::lookChanged;
+    private final UntypedWidgetPropertyListener styleChangedListener    = this::styleChanged;
+    private final UntypedWidgetPropertyListener unitChangedListener     = this::unitChanged;
+    private final WidgetPropertyListener<VType> valueChangedListener    = this::valueChanged;
 
     @SuppressWarnings( "unchecked" )
     @Override
@@ -391,47 +401,93 @@ public abstract class BaseGaugeRepresentation<W extends BaseGaugeWidget> extends
 
         super.registerListeners();
 
-        model_widget.propPrecision().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propPVName().addPropertyListener(this::contentChanged);
+        model_widget.propPrecision().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propPVName().addUntypedPropertyListener(contentChangedListener);
 
-        model_widget.propVisible().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propX().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propY().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propWidth().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::geometryChanged);
+        model_widget.propVisible().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propX().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propY().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propWidth().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(geometryChangedListener);
 
-        model_widget.propAutoScale().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propMajorTickSpace().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propMinorTickSpace().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTitle().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propValueVisible().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propAutoScale().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propMajorTickSpace().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propMinorTickSpace().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTitle().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propValueVisible().addUntypedPropertyListener(lookChangedListener);
 
-        model_widget.propLevelHiHi().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLevelHigh().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLevelLoLo().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLevelLow().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLimitsFromPV().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowHiHi().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowHigh().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowLoLo().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowLow().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propMaximum().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propMinimum().addUntypedPropertyListener(this::limitsChanged);
+        model_widget.propLevelHiHi().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLevelHigh().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLevelLoLo().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLevelLow().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLimitsFromPV().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowHiHi().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowHigh().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowLoLo().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowLow().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propMaximum().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propMinimum().addUntypedPropertyListener(limitsChangedListener);
 
-        model_widget.propUnit().addUntypedPropertyListener(this::unitChanged);
-        model_widget.propUnitFromPV().addUntypedPropertyListener(this::unitChanged);
+        model_widget.propUnit().addUntypedPropertyListener(unitChangedListener);
+        model_widget.propUnitFromPV().addUntypedPropertyListener(unitChangedListener);
 
-        model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propEnabled().addUntypedPropertyListener(styleChangedListener);
 
         if ( toolkit.isEditMode() ) {
             dirtyValue.checkAndClear();
         } else {
-            model_widget.runtimePropValue().addPropertyListener(this::valueChanged);
+            model_widget.runtimePropValue().addPropertyListener(valueChangedListener);
             valueChanged(null, null, null);
         }
+
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        model_widget.propPrecision().removePropertyListener(contentChangedListener);
+        model_widget.propPVName().removePropertyListener(contentChangedListener);
+
+        model_widget.propVisible().removePropertyListener(geometryChangedListener);
+        model_widget.propX().removePropertyListener(geometryChangedListener);
+        model_widget.propY().removePropertyListener(geometryChangedListener);
+        model_widget.propWidth().removePropertyListener(geometryChangedListener);
+        model_widget.propHeight().removePropertyListener(geometryChangedListener);
+
+        model_widget.propAutoScale().removePropertyListener(lookChangedListener);
+        model_widget.propBackgroundColor().removePropertyListener(lookChangedListener);
+        model_widget.propForegroundColor().removePropertyListener(lookChangedListener);
+        model_widget.propMajorTickSpace().removePropertyListener(lookChangedListener);
+        model_widget.propMinorTickSpace().removePropertyListener(lookChangedListener);
+        model_widget.propTitle().removePropertyListener(lookChangedListener);
+        model_widget.propTransparent().removePropertyListener(lookChangedListener);
+        model_widget.propValueVisible().removePropertyListener(lookChangedListener);
+
+        model_widget.propLevelHiHi().removePropertyListener(limitsChangedListener);
+        model_widget.propLevelHigh().removePropertyListener(limitsChangedListener);
+        model_widget.propLevelLoLo().removePropertyListener(limitsChangedListener);
+        model_widget.propLevelLow().removePropertyListener(limitsChangedListener);
+        model_widget.propLimitsFromPV().removePropertyListener(limitsChangedListener);
+        model_widget.propShowHiHi().removePropertyListener(limitsChangedListener);
+        model_widget.propShowHigh().removePropertyListener(limitsChangedListener);
+        model_widget.propShowLoLo().removePropertyListener(limitsChangedListener);
+        model_widget.propShowLow().removePropertyListener(limitsChangedListener);
+        model_widget.propMaximum().removePropertyListener(limitsChangedListener);
+        model_widget.propMinimum().removePropertyListener(limitsChangedListener);
+
+        model_widget.propUnit().removePropertyListener(unitChangedListener);
+        model_widget.propUnitFromPV().removePropertyListener(unitChangedListener);
+
+        model_widget.propEnabled().removePropertyListener(styleChangedListener);
+
+        if ( !toolkit.isEditMode() ) {
+            model_widget.runtimePropValue().removePropertyListener(valueChangedListener);
+        }
+
+        super.unregisterListeners();
 
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseKnobRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseKnobRepresentation.java
@@ -18,7 +18,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.util.FormatOptionHandler;
@@ -60,6 +62,15 @@ public abstract class BaseKnobRepresentation<C extends Knob, W extends KnobWidge
     private volatile double     min           = 0.0;
     private final AtomicBoolean updatingValue = new AtomicBoolean(false);
     private volatile boolean    firstUsage    = true;
+
+    private final UntypedWidgetPropertyListener contentChangedListener  = this::contentChanged;
+    private final UntypedWidgetPropertyListener geometryChangedListener = this::geometryChanged;
+    private final UntypedWidgetPropertyListener limitsChangedListener   = this::limitsChanged;
+    private final UntypedWidgetPropertyListener lookChangedListener     = this::lookChanged;
+    private final UntypedWidgetPropertyListener styleChangedListener    = this::styleChanged;
+    private final UntypedWidgetPropertyListener synchChangedListener    = this::synchChanged;
+    private final UntypedWidgetPropertyListener unitChangedListener     = this::unitChanged;
+    private final WidgetPropertyListener<VType> valueChangedListener    = this::valueChanged;
 
     @SuppressWarnings( "unchecked" )
     @Override
@@ -292,53 +303,106 @@ public abstract class BaseKnobRepresentation<C extends Knob, W extends KnobWidge
 
         super.registerListeners();
 
-        model_widget.propPrecision().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propPVName().addPropertyListener(this::contentChanged);
+        model_widget.propPrecision().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propPVName().addUntypedPropertyListener(contentChangedListener);
 
-        model_widget.propVisible().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propX().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propY().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propWidth().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::geometryChanged);
+        model_widget.propVisible().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propX().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propY().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propWidth().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(geometryChangedListener);
 
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propExtremaVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propThumbColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTagColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTagVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTextColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propValueColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTargetVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propZeroDetentEnabled().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propExtremaVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propThumbColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTagColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTagVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTextColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propValueColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTargetVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propZeroDetentEnabled().addUntypedPropertyListener(lookChangedListener);
 
-        model_widget.propLevelHiHi().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLevelHigh().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLevelLoLo().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLevelLow().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLimitsFromPV().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowHiHi().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowHigh().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowLoLo().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowLow().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowOK().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propMaximum().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propMinimum().addUntypedPropertyListener(this::limitsChanged);
+        model_widget.propLevelHiHi().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLevelHigh().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLevelLoLo().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLevelLow().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLimitsFromPV().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowHiHi().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowHigh().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowLoLo().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowLow().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowOK().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propMaximum().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propMinimum().addUntypedPropertyListener(limitsChangedListener);
 
-        model_widget.propUnit().addUntypedPropertyListener(this::unitChanged);
-        model_widget.propUnitFromPV().addUntypedPropertyListener(this::unitChanged);
+        model_widget.propUnit().addUntypedPropertyListener(unitChangedListener);
+        model_widget.propUnitFromPV().addUntypedPropertyListener(unitChangedListener);
 
-        model_widget.propDragDisabled().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propDragDisabled().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propEnabled().addUntypedPropertyListener(styleChangedListener);
 
         if ( toolkit.isEditMode() ) {
             dirtyValue.checkAndClear();
         } else {
-            model_widget.runtimePropValue().addPropertyListener(this::valueChanged);
-            model_widget.propReadbackPVValue().addPropertyListener(this::valueChanged);
-            model_widget.propSyncedKnob().addUntypedPropertyListener(this::synchChanged);
+            model_widget.runtimePropValue().addPropertyListener(valueChangedListener);
+            model_widget.propReadbackPVValue().addPropertyListener(valueChangedListener);
+            model_widget.propSyncedKnob().addUntypedPropertyListener(synchChangedListener);
         }
+
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        model_widget.propPrecision().removePropertyListener(contentChangedListener);
+        model_widget.propPVName().removePropertyListener(contentChangedListener);
+
+        model_widget.propVisible().removePropertyListener(geometryChangedListener);
+        model_widget.propX().removePropertyListener(geometryChangedListener);
+        model_widget.propY().removePropertyListener(geometryChangedListener);
+        model_widget.propWidth().removePropertyListener(geometryChangedListener);
+        model_widget.propHeight().removePropertyListener(geometryChangedListener);
+
+        model_widget.propBackgroundColor().removePropertyListener(lookChangedListener);
+        model_widget.propColor().removePropertyListener(lookChangedListener);
+        model_widget.propExtremaVisible().removePropertyListener(lookChangedListener);
+        model_widget.propThumbColor().removePropertyListener(lookChangedListener);
+        model_widget.propTagColor().removePropertyListener(lookChangedListener);
+        model_widget.propTagVisible().removePropertyListener(lookChangedListener);
+        model_widget.propTextColor().removePropertyListener(lookChangedListener);
+        model_widget.propTransparent().removePropertyListener(lookChangedListener);
+        model_widget.propValueColor().removePropertyListener(lookChangedListener);
+        model_widget.propTargetVisible().removePropertyListener(lookChangedListener);
+        model_widget.propZeroDetentEnabled().removePropertyListener(lookChangedListener);
+
+        model_widget.propLevelHiHi().removePropertyListener(limitsChangedListener);
+        model_widget.propLevelHigh().removePropertyListener(limitsChangedListener);
+        model_widget.propLevelLoLo().removePropertyListener(limitsChangedListener);
+        model_widget.propLevelLow().removePropertyListener(limitsChangedListener);
+        model_widget.propLimitsFromPV().removePropertyListener(limitsChangedListener);
+        model_widget.propShowHiHi().removePropertyListener(limitsChangedListener);
+        model_widget.propShowHigh().removePropertyListener(limitsChangedListener);
+        model_widget.propShowLoLo().removePropertyListener(limitsChangedListener);
+        model_widget.propShowLow().removePropertyListener(limitsChangedListener);
+        model_widget.propShowOK().removePropertyListener(limitsChangedListener);
+        model_widget.propMaximum().removePropertyListener(limitsChangedListener);
+        model_widget.propMinimum().removePropertyListener(limitsChangedListener);
+
+        model_widget.propUnit().removePropertyListener(unitChangedListener);
+        model_widget.propUnitFromPV().removePropertyListener(unitChangedListener);
+
+        model_widget.propDragDisabled().removePropertyListener(styleChangedListener);
+        model_widget.propEnabled().removePropertyListener(styleChangedListener);
+
+        if ( !toolkit.isEditMode() ) {
+            model_widget.runtimePropValue().removePropertyListener(valueChangedListener);
+            model_widget.propReadbackPVValue().removePropertyListener(valueChangedListener);
+            model_widget.propSyncedKnob().removePropertyListener(synchChangedListener);
+        }
+
+        super.unregisterListeners();
 
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -8,7 +8,9 @@
 package org.csstudio.display.builder.representation.javafx.widgets;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.widgets.BaseLEDWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
 import org.diirt.vtype.AlarmSeverity;
@@ -35,13 +37,16 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
     protected volatile Color[] colors = new Color[0];
 
     protected volatile Color value_color;
-
     protected volatile String value_label;
 
     /** Actual LED Ellipse or Rectangle inside {@link Pane} to allow for border */
     private Shape led;
 
     protected Label label;
+
+    private final UntypedWidgetPropertyListener styleChangedListener = this::styleChanged;
+    private final WidgetPropertyListener<VType> contentChangedListener = this::contentChanged;
+    private final WidgetPropertyListener<Boolean> typeChangedListener = this::typeChanged;
 
     @Override
     public Pane createJFXNode() throws Exception
@@ -100,14 +105,27 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propSquare().addPropertyListener(this::typeChanged);
-        model_widget.propWidth().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propLineColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.runtimePropValue().addPropertyListener(this::contentChanged);
+        model_widget.propSquare().addPropertyListener(typeChangedListener);
+        model_widget.propWidth().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propLineColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.runtimePropValue().addPropertyListener(contentChangedListener);
         contentChanged(null, null, null);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propSquare().removePropertyListener(typeChangedListener);
+        model_widget.propWidth().removePropertyListener(styleChangedListener);
+        model_widget.propHeight().removePropertyListener(styleChangedListener);
+        model_widget.propFont().removePropertyListener(styleChangedListener);
+        model_widget.propForegroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propLineColor().removePropertyListener(styleChangedListener);
+        model_widget.runtimePropValue().removePropertyListener(contentChangedListener);
+        super.unregisterListeners();
     }
 
     private void typeChanged(final WidgetProperty<Boolean> property, final Boolean old_value, final Boolean new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseMeterRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseMeterRepresentation.java
@@ -12,6 +12,7 @@ package org.csstudio.display.builder.representation.javafx.widgets;
 import java.util.Objects;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.BaseMeterWidget;
 
@@ -28,7 +29,8 @@ import javafx.scene.paint.Color;
  */
 public abstract class BaseMeterRepresentation<W extends BaseMeterWidget> extends BaseGaugeRepresentation<W> {
 
-    private final DirtyFlag dirtyLook = new DirtyFlag();
+    private final DirtyFlag                     dirtyLook           = new DirtyFlag();
+    private final UntypedWidgetPropertyListener lookChangedListener = this::lookChanged;
 
     @Override
     public void updateChanges ( ) {
@@ -133,9 +135,20 @@ public abstract class BaseMeterRepresentation<W extends BaseMeterWidget> extends
 
         super.registerListeners();
 
-        model_widget.propLcdDesign().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLcdFont().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLcdVisible().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propLcdDesign().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLcdFont().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLcdVisible().addUntypedPropertyListener(lookChangedListener);
+
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        model_widget.propLcdDesign().removePropertyListener(lookChangedListener);
+        model_widget.propLcdFont().removePropertyListener(lookChangedListener);
+        model_widget.propLcdVisible().removePropertyListener(lookChangedListener);
+
+        super.unregisterListeners();
 
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
@@ -14,7 +14,9 @@ import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.util.ModelResourceUtil;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.BoolButtonWidget;
@@ -68,6 +70,12 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
     private volatile String value_label;
     private volatile ImageView[] state_images;
     private volatile ImageView value_image;
+
+    private final UntypedWidgetPropertyListener imagesChangedListener = this::imagesChanged;
+    private final UntypedWidgetPropertyListener representationChangedListener = this::representationChanged;
+    private final WidgetPropertyListener<Integer> bitChangedListener = this::bitChanged;
+    private final WidgetPropertyListener<Boolean> enablementChangedListener = this::enablementChanged;
+    private final WidgetPropertyListener<VType> valueChangedListener = this::valueChanged;
 
     @Override
     public ButtonBase createJFXNode() throws Exception
@@ -133,27 +141,49 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
     {
         super.registerListeners();
         representationChanged(null,null,null);
-        model_widget.propWidth().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propOffLabel().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propOffImage().addUntypedPropertyListener(this::imagesChanged);
-        model_widget.propOffColor().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propOnLabel().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propOnImage().addUntypedPropertyListener(this::imagesChanged);
-        model_widget.propOnColor().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propShowLED().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::representationChanged);
-        model_widget.propEnabled().addPropertyListener(this::enablementChanged);
-        model_widget.runtimePropPVWritable().addPropertyListener(this::enablementChanged);
-        model_widget.propBit().addPropertyListener(this::bitChanged);
-        model_widget.runtimePropValue().addPropertyListener(this::valueChanged);
+        model_widget.propWidth().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propOffLabel().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propOffImage().addUntypedPropertyListener(imagesChangedListener);
+        model_widget.propOffColor().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propOnLabel().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propOnImage().addUntypedPropertyListener(imagesChangedListener);
+        model_widget.propOnColor().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propShowLED().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(representationChangedListener);
+        model_widget.propEnabled().addPropertyListener(enablementChangedListener);
+        model_widget.runtimePropPVWritable().addPropertyListener(enablementChangedListener);
+        model_widget.propBit().addPropertyListener(bitChangedListener);
+        model_widget.runtimePropValue().addPropertyListener(valueChangedListener);
 
         imagesChanged(null, null, null);
         bitChanged(model_widget.propBit(), null, model_widget.propBit().getValue());
         enablementChanged(null, null, null);
         valueChanged(null, null, model_widget.runtimePropValue().getValue());
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(representationChangedListener);
+        model_widget.propHeight().removePropertyListener(representationChangedListener);
+        model_widget.propOffLabel().removePropertyListener(representationChangedListener);
+        model_widget.propOffImage().removePropertyListener(imagesChangedListener);
+        model_widget.propOffColor().removePropertyListener(representationChangedListener);
+        model_widget.propOnLabel().removePropertyListener(representationChangedListener);
+        model_widget.propOnImage().removePropertyListener(imagesChangedListener);
+        model_widget.propOnColor().removePropertyListener(representationChangedListener);
+        model_widget.propShowLED().removePropertyListener(representationChangedListener);
+        model_widget.propFont().removePropertyListener(representationChangedListener);
+        model_widget.propForegroundColor().removePropertyListener(representationChangedListener);
+        model_widget.propBackgroundColor().removePropertyListener(representationChangedListener);
+        model_widget.propEnabled().removePropertyListener(enablementChangedListener);
+        model_widget.runtimePropPVWritable().removePropertyListener(enablementChangedListener);
+        model_widget.propBit().removePropertyListener(bitChangedListener);
+        model_widget.runtimePropValue().removePropertyListener(valueChangedListener);
+        super.unregisterListeners();
     }
 
     private void stateChanged()

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.properties.StringWidgetProperty;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.ByteMonitorWidget;
@@ -37,7 +38,6 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
 {
     private final DirtyFlag dirty_config = new DirtyFlag();
     private final DirtyFlag dirty_content = new DirtyFlag();
-    private final UntypedWidgetPropertyListener look_listener = this::lookChanged;
 
     private volatile Color[] colors;
 
@@ -50,6 +50,13 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
     private volatile boolean square_led = false;
 
     private volatile Shape[] leds = null;
+
+    private final UntypedWidgetPropertyListener configChangedListener = this::configChanged;
+    private final UntypedWidgetPropertyListener lookChangeddListener = this::lookChanged;
+    private final WidgetPropertyListener<VType> contentChangedListener = this::contentChanged;
+    private final WidgetPropertyListener<List<StringWidgetProperty>> labelsChangedListener = this::labelsChanged;
+    private final WidgetPropertyListener<Boolean> orientationChangedListener = this::orientationChanged;
+    private final WidgetPropertyListener<Integer> sizeChangedListener = this::sizeChanged;
 
     @Override
     protected Pane createJFXNode() throws Exception
@@ -219,22 +226,22 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addPropertyListener(this::sizeChanged);
-        model_widget.propHeight().addPropertyListener(this::sizeChanged);
+        model_widget.propWidth().addPropertyListener(sizeChangedListener);
+        model_widget.propHeight().addPropertyListener(sizeChangedListener);
 
-        model_widget.runtimePropValue().addPropertyListener(this::contentChanged);
+        model_widget.runtimePropValue().addPropertyListener(contentChangedListener);
 
-        model_widget.propOffColor().addUntypedPropertyListener(this::configChanged);
-        model_widget.propOnColor().addUntypedPropertyListener(this::configChanged);
-        model_widget.propStartBit().addUntypedPropertyListener(this::configChanged);
+        model_widget.propOffColor().addUntypedPropertyListener(configChangedListener);
+        model_widget.propOnColor().addUntypedPropertyListener(configChangedListener);
+        model_widget.propStartBit().addUntypedPropertyListener(configChangedListener);
 
-        model_widget.propBitReverse().addUntypedPropertyListener(look_listener);
-        model_widget.propForegroundColor().addUntypedPropertyListener(look_listener);
-        model_widget.propFont().addUntypedPropertyListener(look_listener);
-        model_widget.propLabels().addPropertyListener(this::labelsChanged);
-        model_widget.propNumBits().addUntypedPropertyListener(look_listener);
-        model_widget.propHorizontal().addPropertyListener(this::orientationChanged);
-        model_widget.propSquare().addUntypedPropertyListener(look_listener);
+        model_widget.propBitReverse().addUntypedPropertyListener(lookChangeddListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(lookChangeddListener);
+        model_widget.propFont().addUntypedPropertyListener(lookChangeddListener);
+        model_widget.propLabels().addPropertyListener(labelsChangedListener);
+        model_widget.propNumBits().addUntypedPropertyListener(lookChangeddListener);
+        model_widget.propHorizontal().addPropertyListener(orientationChangedListener);
+        model_widget.propSquare().addUntypedPropertyListener(lookChangeddListener);
 
         //initialization
         labelsChanged(model_widget.propLabels(), null, model_widget.propLabels().getValue());
@@ -242,16 +249,41 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
         contentChanged(null, null, model_widget.runtimePropValue().getValue());
     }
 
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(sizeChangedListener);
+        model_widget.propHeight().removePropertyListener(sizeChangedListener);
+
+        model_widget.runtimePropValue().removePropertyListener(contentChangedListener);
+
+        model_widget.propOffColor().removePropertyListener(configChangedListener);
+        model_widget.propOnColor().removePropertyListener(configChangedListener);
+        model_widget.propStartBit().removePropertyListener(configChangedListener);
+
+        model_widget.propBitReverse().removePropertyListener(lookChangeddListener);
+        model_widget.propForegroundColor().removePropertyListener(lookChangeddListener);
+        model_widget.propFont().removePropertyListener(lookChangeddListener);
+        model_widget.propLabels().removePropertyListener(labelsChangedListener);
+        model_widget.propNumBits().removePropertyListener(lookChangeddListener);
+        model_widget.propHorizontal().removePropertyListener(orientationChangedListener);
+        model_widget.propSquare().removePropertyListener(lookChangeddListener);
+
+        labelsChanged(model_widget.propLabels(), model_widget.propLabels().getValue(), null);
+
+        super.unregisterListeners();
+    }
+
     private void labelsChanged(final WidgetProperty<List<StringWidgetProperty>> prop,
                                final List<StringWidgetProperty> removed, final List<StringWidgetProperty> added)
     {
         if (added != null)
             for (StringWidgetProperty text : added)
-                text.addUntypedPropertyListener(look_listener);
+                text.addUntypedPropertyListener(lookChangeddListener);
         if (removed != null)
             for (StringWidgetProperty text : removed)
-                text.removePropertyListener(look_listener);
-        look_listener.propertyChanged(null, null, null);
+                text.removePropertyListener(lookChangeddListener);
+        lookChangeddListener.propertyChanged(null, null, null);
     }
 
     private void orientationChanged(final WidgetProperty<Boolean> prop, final Boolean old, final Boolean horizontal)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/CheckBoxRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/CheckBoxRepresentation.java
@@ -12,7 +12,9 @@ import static org.csstudio.display.builder.representation.ToolkitRepresentation.
 import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.CheckBoxWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -38,6 +40,12 @@ public class CheckBoxRepresentation extends RegionBaseRepresentation<CheckBox, C
     protected volatile boolean state = false;
     protected volatile String label = "";
     protected volatile boolean enabled = true;
+
+    private final UntypedWidgetPropertyListener sizeChangedListener = this::sizeChanged;
+    private final UntypedWidgetPropertyListener styleChangedListener = this::styleChanged;
+    private final WidgetPropertyListener<Integer> bitChangedListener = this::bitChanged;
+    private final WidgetPropertyListener<String> labelChangedListener = this::labelChanged;
+    private final WidgetPropertyListener<VType> valueChangedListener = this::valueChanged;
 
     @Override
     protected final CheckBox createJFXNode() throws Exception
@@ -112,24 +120,43 @@ public class CheckBoxRepresentation extends RegionBaseRepresentation<CheckBox, C
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::sizeChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::sizeChanged);
-        model_widget.propAutoSize().addUntypedPropertyListener(this::sizeChanged);
+        model_widget.propWidth().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propAutoSize().addUntypedPropertyListener(sizeChangedListener);
 
         labelChanged(model_widget.propLabel(), null, model_widget.propLabel().getValue());
-        model_widget.propLabel().addPropertyListener(this::labelChanged);
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
-        model_widget.runtimePropPVWritable().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propLabel().addPropertyListener(labelChangedListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propEnabled().addUntypedPropertyListener(styleChangedListener);
+        model_widget.runtimePropPVWritable().addUntypedPropertyListener(styleChangedListener);
 
         bitChanged(model_widget.propBit(), null, model_widget.propBit().getValue());
-        model_widget.propBit().addPropertyListener(this::bitChanged);
-        model_widget.runtimePropValue().addPropertyListener(this::valueChanged);
+        model_widget.propBit().addPropertyListener(bitChangedListener);
+        model_widget.runtimePropValue().addPropertyListener(valueChangedListener);
 
         // Initial Update
         valueChanged(null, null, model_widget.runtimePropValue().getValue());
    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(sizeChangedListener);
+        model_widget.propHeight().removePropertyListener(sizeChangedListener);
+        model_widget.propAutoSize().removePropertyListener(sizeChangedListener);
+
+        model_widget.propLabel().removePropertyListener(labelChangedListener);
+        model_widget.propForegroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propFont().removePropertyListener(styleChangedListener);
+        model_widget.propEnabled().removePropertyListener(styleChangedListener);
+        model_widget.runtimePropPVWritable().removePropertyListener(styleChangedListener);
+
+        model_widget.propBit().removePropertyListener(bitChangedListener);
+        model_widget.runtimePropValue().removePropertyListener(valueChangedListener);
+
+        super.unregisterListeners();
+    }
 
     private void sizeChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
     {

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ClockRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ClockRepresentation.java
@@ -12,6 +12,7 @@ package org.csstudio.display.builder.representation.javafx.widgets;
 import java.util.Objects;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.ClockWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -31,6 +32,9 @@ public class ClockRepresentation extends BaseClockRepresentation<ClockWidget> {
 
     private final DirtyFlag dirtyBehavior = new DirtyFlag();
     private final DirtyFlag dirtyLook     = new DirtyFlag();
+
+    private final UntypedWidgetPropertyListener behaviorChangedListener = this::behaviorChanged;
+    private final UntypedWidgetPropertyListener lookChangedListener     = this::lookChanged;
 
     @Override
     public void updateChanges ( ) {
@@ -316,29 +320,60 @@ public class ClockRepresentation extends BaseClockRepresentation<ClockWidget> {
 
         super.registerListeners();
 
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propDateColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propHourColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propHourTickMarkColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propHourTickMarkVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propKnobColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propMinuteColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propMinuteTickMarkColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propMinuteTickMarkVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propRingColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propRingWidth().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propSecondColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propSkin().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTextColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTextVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTickLabelColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTickLabelsVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTitleColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propDateColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propHourColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propHourTickMarkColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propHourTickMarkVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propKnobColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propMinuteColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propMinuteTickMarkColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propMinuteTickMarkVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propRingColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propRingWidth().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propSecondColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propSkin().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTextColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTextVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTickLabelColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTickLabelsVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTitleColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(lookChangedListener);
 
-        model_widget.propDiscreteHours().addUntypedPropertyListener(this::behaviorChanged);
-        model_widget.propDiscreteMinutes().addUntypedPropertyListener(this::behaviorChanged);
-        model_widget.propDiscreteSeconds().addUntypedPropertyListener(this::behaviorChanged);
+        model_widget.propDiscreteHours().addUntypedPropertyListener(behaviorChangedListener);
+        model_widget.propDiscreteMinutes().addUntypedPropertyListener(behaviorChangedListener);
+        model_widget.propDiscreteSeconds().addUntypedPropertyListener(behaviorChangedListener);
+
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        model_widget.propBackgroundColor().removePropertyListener(lookChangedListener);
+        model_widget.propDateColor().removePropertyListener(lookChangedListener);
+        model_widget.propHourColor().removePropertyListener(lookChangedListener);
+        model_widget.propHourTickMarkColor().removePropertyListener(lookChangedListener);
+        model_widget.propHourTickMarkVisible().removePropertyListener(lookChangedListener);
+        model_widget.propKnobColor().removePropertyListener(lookChangedListener);
+        model_widget.propMinuteColor().removePropertyListener(lookChangedListener);
+        model_widget.propMinuteTickMarkColor().removePropertyListener(lookChangedListener);
+        model_widget.propMinuteTickMarkVisible().removePropertyListener(lookChangedListener);
+        model_widget.propRingColor().removePropertyListener(lookChangedListener);
+        model_widget.propRingWidth().removePropertyListener(lookChangedListener);
+        model_widget.propSecondColor().removePropertyListener(lookChangedListener);
+        model_widget.propSkin().removePropertyListener(lookChangedListener);
+        model_widget.propTextColor().removePropertyListener(lookChangedListener);
+        model_widget.propTextVisible().removePropertyListener(lookChangedListener);
+        model_widget.propTickLabelColor().removePropertyListener(lookChangedListener);
+        model_widget.propTickLabelsVisible().removePropertyListener(lookChangedListener);
+        model_widget.propTitleColor().removePropertyListener(lookChangedListener);
+        model_widget.propTransparent().removePropertyListener(lookChangedListener);
+
+        model_widget.propDiscreteHours().removePropertyListener(behaviorChangedListener);
+        model_widget.propDiscreteMinutes().removePropertyListener(behaviorChangedListener);
+        model_widget.propDiscreteSeconds().removePropertyListener(behaviorChangedListener);
+
+        super.unregisterListeners();
 
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ComboRepresentation.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.ComboWidget;
@@ -42,6 +43,10 @@ public class ComboRepresentation extends RegionBaseRepresentation<ComboBox<Strin
     private final DirtyFlag dirty_enable = new DirtyFlag();
     private volatile List<String> items = Collections.emptyList();
     private volatile int index = -1;
+
+    private final UntypedWidgetPropertyListener contentChangedListener = this::contentChanged;
+    private final UntypedWidgetPropertyListener enableChangedListener = this::enableChanged;
+    private final UntypedWidgetPropertyListener styleChangedListener = this::styleChanged;
 
     @Override
     public ComboBox<String> createJFXNode() throws Exception
@@ -113,20 +118,38 @@ public class ComboRepresentation extends RegionBaseRepresentation<ComboBox<Strin
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propWidth().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(styleChangedListener);
 
-        model_widget.runtimePropValue().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propItemsFromPV().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propItems().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propEnabled().addUntypedPropertyListener(this::enableChanged);
-        model_widget.runtimePropPVWritable().addUntypedPropertyListener(this::enableChanged);
+        model_widget.runtimePropValue().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propItemsFromPV().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propItems().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propEnabled().addUntypedPropertyListener(enableChangedListener);
+        model_widget.runtimePropPVWritable().addUntypedPropertyListener(enableChangedListener);
 
         styleChanged(null, null, null);
         contentChanged(null, null, null);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(styleChangedListener);
+        model_widget.propHeight().removePropertyListener(styleChangedListener);
+        model_widget.propForegroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propBackgroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propFont().removePropertyListener(styleChangedListener);
+
+        model_widget.runtimePropValue().removePropertyListener(contentChangedListener);
+        model_widget.propItemsFromPV().removePropertyListener(contentChangedListener);
+        model_widget.propItems().removePropertyListener(contentChangedListener);
+        model_widget.propEnabled().removePropertyListener(enableChangedListener);
+        model_widget.runtimePropPVWritable().removePropertyListener(enableChangedListener);
+
+        super.unregisterListeners();
     }
 
     private void confirm(final String value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/DigitalClockRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/DigitalClockRepresentation.java
@@ -12,6 +12,7 @@ package org.csstudio.display.builder.representation.javafx.widgets;
 import java.util.Objects;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.DigitalClockWidget;
 import org.csstudio.display.builder.model.widgets.DigitalClockWidget.Design;
@@ -29,7 +30,8 @@ import eu.hansolo.medusa.LcdFont;
 @SuppressWarnings("nls")
 public class DigitalClockRepresentation extends BaseClockRepresentation<DigitalClockWidget> {
 
-    private final DirtyFlag dirtyLook = new DirtyFlag();
+    private final DirtyFlag                     dirtyLook           = new DirtyFlag();
+    private final UntypedWidgetPropertyListener lookChangedListener = this::lookChanged;
 
     @Override
     public void updateChanges ( ) {
@@ -92,9 +94,20 @@ public class DigitalClockRepresentation extends BaseClockRepresentation<DigitalC
 
         super.registerListeners();
 
-        model_widget.propLcdCrystalEnabled().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLcdDesign().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLcdFont().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propLcdCrystalEnabled().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLcdDesign().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLcdFont().addUntypedPropertyListener(lookChangedListener);
+
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        model_widget.propLcdCrystalEnabled().removePropertyListener(lookChangedListener);
+        model_widget.propLcdDesign().removePropertyListener(lookChangedListener);
+        model_widget.propLcdFont().removePropertyListener(lookChangedListener);
+
+        super.unregisterListeners();
 
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EllipseRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EllipseRepresentation.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.representation.javafx.widgets;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.EllipseWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -24,6 +25,8 @@ public class EllipseRepresentation extends JFXBaseRepresentation<Ellipse, Ellips
     private final DirtyFlag dirty_position = new DirtyFlag();
     private final DirtyFlag dirty_look = new DirtyFlag();
     private Color background, line_color;
+    private final UntypedWidgetPropertyListener lookChangedListener = this::lookChanged;
+    private final UntypedWidgetPropertyListener positionChangedListener = this::positionChanged;
 
     @Override
     public Ellipse createJFXNode() throws Exception
@@ -41,17 +44,41 @@ public class EllipseRepresentation extends JFXBaseRepresentation<Ellipse, Ellips
         // ==> Tooltip must be attached explicitly.
         if (! toolkit.isEditMode())
             attachTooltip();
-        // ==> Visibility and position nust be handled explicitly.
-        model_widget.propVisible().addUntypedPropertyListener(this::positionChanged);
-        model_widget.propX().addUntypedPropertyListener(this::positionChanged);
-        model_widget.propY().addUntypedPropertyListener(this::positionChanged);
-        model_widget.propWidth().addUntypedPropertyListener(this::positionChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::positionChanged);
+        // ==> Visibility and position must be handled explicitly.
+        model_widget.propVisible().addUntypedPropertyListener(positionChangedListener);
+        model_widget.propX().addUntypedPropertyListener(positionChangedListener);
+        model_widget.propY().addUntypedPropertyListener(positionChangedListener);
+        model_widget.propWidth().addUntypedPropertyListener(positionChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(positionChangedListener);
 
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLineColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLineWidth().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLineColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLineWidth().addUntypedPropertyListener(lookChangedListener);
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        // JFX Ellipse is based on center, not top-left corner,
+        // so can't use the default from super.unregisterListeners();
+        // ==> Tooltip must be detached explicitly.
+        if ( !toolkit.isEditMode() ) {
+            detachTooltip();
+        }
+
+        // ==> Visibility and position must be handled explicitly.
+        model_widget.propVisible().removePropertyListener(positionChangedListener);
+        model_widget.propX().removePropertyListener(positionChangedListener);
+        model_widget.propY().removePropertyListener(positionChangedListener);
+        model_widget.propWidth().removePropertyListener(positionChangedListener);
+        model_widget.propHeight().removePropertyListener(positionChangedListener);
+
+        model_widget.propBackgroundColor().removePropertyListener(lookChangedListener);
+        model_widget.propTransparent().removePropertyListener(lookChangedListener);
+        model_widget.propLineColor().removePropertyListener(lookChangedListener);
+        model_widget.propLineWidth().removePropertyListener(lookChangedListener);
+
     }
 
     private void positionChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EllipseRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EllipseRepresentation.java
@@ -58,14 +58,13 @@ public class EllipseRepresentation extends JFXBaseRepresentation<Ellipse, Ellips
     }
 
     @Override
-    protected void unregisterListeners ( ) {
-
+    protected void unregisterListeners ( )
+    {
         // JFX Ellipse is based on center, not top-left corner,
         // so can't use the default from super.unregisterListeners();
         // ==> Tooltip must be detached explicitly.
-        if ( !toolkit.isEditMode() ) {
+        if ( !toolkit.isEditMode() )
             detachTooltip();
-        }
 
         // ==> Visibility and position must be handled explicitly.
         model_widget.propVisible().removePropertyListener(positionChangedListener);
@@ -78,7 +77,6 @@ public class EllipseRepresentation extends JFXBaseRepresentation<Ellipse, Ellips
         model_widget.propTransparent().removePropertyListener(lookChangedListener);
         model_widget.propLineColor().removePropertyListener(lookChangedListener);
         model_widget.propLineWidth().removePropertyListener(lookChangedListener);
-
     }
 
     private void positionChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
@@ -17,6 +17,7 @@ import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.util.ModelThreadPool;
 import org.csstudio.display.builder.model.widgets.EmbeddedDisplayWidget;
@@ -84,6 +85,10 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
     /** Flag to avoid recursion when this code changes the widget size */
     private volatile boolean resizing = false;
 
+    private final UntypedWidgetPropertyListener backgroundChangedListener = this::backgroundChanged;
+    private final UntypedWidgetPropertyListener fileChangedListener = this::fileChanged;
+    private final UntypedWidgetPropertyListener sizesChangedListener = this::sizesChanged;
+
     @Override
     protected boolean isFilteringEditModeClicks()
     {
@@ -118,16 +123,32 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::sizesChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::sizesChanged);
-        model_widget.propResize().addUntypedPropertyListener(this::sizesChanged);
+        model_widget.propWidth().addUntypedPropertyListener(sizesChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(sizesChangedListener);
+        model_widget.propResize().addUntypedPropertyListener(sizesChangedListener);
 
-        model_widget.propFile().addUntypedPropertyListener(this::fileChanged);
-        model_widget.propGroupName().addUntypedPropertyListener(this::fileChanged);
-        model_widget.propMacros().addUntypedPropertyListener(this::fileChanged);
+        model_widget.propFile().addUntypedPropertyListener(fileChangedListener);
+        model_widget.propGroupName().addUntypedPropertyListener(fileChangedListener);
+        model_widget.propMacros().addUntypedPropertyListener(fileChangedListener);
 
-        model_widget.propTransparent().addUntypedPropertyListener(this::backgroundChanged);
+        model_widget.propTransparent().addUntypedPropertyListener(backgroundChangedListener);
         fileChanged(null, null, null);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(sizesChangedListener);
+        model_widget.propHeight().removePropertyListener(sizesChangedListener);
+        model_widget.propResize().removePropertyListener(sizesChangedListener);
+
+        model_widget.propFile().removePropertyListener(fileChangedListener);
+        model_widget.propGroupName().removePropertyListener(fileChangedListener);
+        model_widget.propMacros().removePropertyListener(fileChangedListener);
+
+        model_widget.propTransparent().removePropertyListener(backgroundChangedListener);
+
+        super.unregisterListeners();
     }
 
     private void sizesChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
@@ -224,7 +245,7 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
 
             // Atomically update the 'active' model
             final DisplayModel old_model = active_content_model.getAndSet(new_model);
-            new_model.propBackgroundColor().addUntypedPropertyListener(this::backgroundChanged);
+            new_model.propBackgroundColor().addUntypedPropertyListener(backgroundChangedListener);
 
             if (old_model != null)
             {   // Dispose old model

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/GaugeRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/GaugeRepresentation.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
@@ -30,8 +31,9 @@ import javafx.scene.paint.Color;
  */
 public class GaugeRepresentation extends BaseGaugeRepresentation<GaugeWidget> {
 
-    private final DirtyFlag  dirtyLook = new DirtyFlag();
-    private GaugeWidget.Skin skin      = null;
+    private final DirtyFlag                     dirtyLook           = new DirtyFlag();
+    private final UntypedWidgetPropertyListener lookChangedListener = this::lookChanged;
+    private GaugeWidget.Skin                    skin                = null;
 
     @Override
     public void updateChanges ( ) {
@@ -123,10 +125,22 @@ public class GaugeRepresentation extends BaseGaugeRepresentation<GaugeWidget> {
 
         super.registerListeners();
 
-        model_widget.propSkin().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propBarBackgroundColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propBarColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propStartFromZero().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propSkin().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propBarBackgroundColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propBarColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propStartFromZero().addUntypedPropertyListener(lookChangedListener);
+
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        model_widget.propSkin().removePropertyListener(lookChangedListener);
+        model_widget.propBarBackgroundColor().removePropertyListener(lookChangedListener);
+        model_widget.propBarColor().removePropertyListener(lookChangedListener);
+        model_widget.propStartFromZero().removePropertyListener(lookChangedListener);
+
+        super.unregisterListeners();
 
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/GroupRepresentation.java
@@ -63,6 +63,7 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
     private volatile boolean firstUpdate = true;
     private volatile int inset = 10;
     private volatile Color foreground_color, background_color;
+    private final UntypedWidgetPropertyListener borderChangedListener = this::borderChanged;
 
     @Override
     public Pane createJFXNode() throws Exception
@@ -85,15 +86,28 @@ public class GroupRepresentation extends JFXBaseRepresentation<Pane, GroupWidget
     protected void registerListeners()
     {
         super.registerListeners();
-        final UntypedWidgetPropertyListener listener = this::borderChanged;
-        model_widget.propForegroundColor().addUntypedPropertyListener(listener);
-        model_widget.propBackgroundColor().addUntypedPropertyListener(listener);
-        model_widget.propTransparent().addUntypedPropertyListener(listener);
-        model_widget.propName().addUntypedPropertyListener(listener);
-        model_widget.propStyle().addUntypedPropertyListener(listener);
-        model_widget.propFont().addUntypedPropertyListener(listener);
-        model_widget.propWidth().addUntypedPropertyListener(listener);
-        model_widget.propHeight().addUntypedPropertyListener(listener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(borderChangedListener);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(borderChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(borderChangedListener);
+        model_widget.propName().addUntypedPropertyListener(borderChangedListener);
+        model_widget.propStyle().addUntypedPropertyListener(borderChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(borderChangedListener);
+        model_widget.propWidth().addUntypedPropertyListener(borderChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(borderChangedListener);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propForegroundColor().removePropertyListener(borderChangedListener);
+        model_widget.propBackgroundColor().removePropertyListener(borderChangedListener);
+        model_widget.propTransparent().removePropertyListener(borderChangedListener);
+        model_widget.propName().removePropertyListener(borderChangedListener);
+        model_widget.propStyle().removePropertyListener(borderChangedListener);
+        model_widget.propFont().removePropertyListener(borderChangedListener);
+        model_widget.propWidth().removePropertyListener(borderChangedListener);
+        model_widget.propHeight().removePropertyListener(borderChangedListener);
+        super.unregisterListeners();
     }
 
     private void borderChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import org.csstudio.display.builder.model.ChildrenProperty;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.Widget;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.properties.CommonWidgetProperties;
@@ -43,6 +44,8 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
     private volatile WidgetProperty<Boolean> visible;
 
     private final DirtyFlag dirty_position = new DirtyFlag();
+    private final UntypedWidgetPropertyListener positionChangedListener = this::positionChanged;
+
 
     /** {@inheritDoc} */
     @Override
@@ -173,6 +176,7 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
     @Override
     public void dispose()
     {
+        unregisterListeners();
         Objects.requireNonNull(jfx_node);
         JFXRepresentation.getChildren(jfx_node.getParent()).remove(jfx_node);
         jfx_node = null;
@@ -202,9 +206,9 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
     {
         visible = model_widget.checkProperty(CommonWidgetProperties.propVisible).orElse(null);
         if (visible != null)
-            visible.addUntypedPropertyListener(this::positionChanged);
-        model_widget.propX().addUntypedPropertyListener(this::positionChanged);
-        model_widget.propY().addUntypedPropertyListener(this::positionChanged);
+            visible.addUntypedPropertyListener(positionChangedListener);
+        model_widget.propX().addUntypedPropertyListener(positionChangedListener);
+        model_widget.propY().addUntypedPropertyListener(positionChangedListener);
         // Would like to also listen to positionWidth & height,
         // then call jfx_node.resizeRelocate(x, y, width, height),
         // but resizeRelocate tends to ignore the width & height on
@@ -213,6 +217,28 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
 
         if (! toolkit.isEditMode())
             attachTooltip();
+    }
+
+    /**
+     * Unregister model widget listeners.
+     * <p>
+     * Override must call base class.</p>
+     */
+    protected void unregisterListeners() {
+
+        visible = model_widget.checkProperty(CommonWidgetProperties.propVisible).orElse(null);
+
+        if ( visible != null ) {
+            visible.removePropertyListener(positionChangedListener);
+        }
+
+        model_widget.propX().removePropertyListener(positionChangedListener);
+        model_widget.propY().removePropertyListener(positionChangedListener);
+
+        if ( !toolkit.isEditMode() ) {
+            detachTooltip();
+        }
+
     }
 
     /** Attach tool tip support
@@ -226,6 +252,13 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
     {
         model_widget.checkProperty(CommonWidgetProperties.propTooltip)
                     .ifPresent(prop -> TooltipSupport.attach(jfx_node, prop));
+    }
+
+    /**
+     * Detach tool tip support.
+     */
+    protected void detachTooltip ( ) {
+        TooltipSupport.detach(jfx_node);
     }
 
     private void positionChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
@@ -224,21 +224,16 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
      * <p>
      * Override must call base class.</p>
      */
-    protected void unregisterListeners() {
-
+    protected void unregisterListeners()
+    {
         visible = model_widget.checkProperty(CommonWidgetProperties.propVisible).orElse(null);
-
-        if ( visible != null ) {
+        if ( visible != null )
             visible.removePropertyListener(positionChangedListener);
-        }
-
         model_widget.propX().removePropertyListener(positionChangedListener);
         model_widget.propY().removePropertyListener(positionChangedListener);
 
-        if ( !toolkit.isEditMode() ) {
+        if ( !toolkit.isEditMode() )
             detachTooltip();
-        }
-
     }
 
     /** Attach tool tip support
@@ -257,7 +252,8 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
     /**
      * Detach tool tip support.
      */
-    protected void detachTooltip ( ) {
+    protected void detachTooltip ( )
+    {
         TooltipSupport.detach(jfx_node);
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/LEDRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/LEDRepresentation.java
@@ -9,6 +9,7 @@ package org.csstudio.display.builder.representation.javafx.widgets;
 
 import java.util.List;
 
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.LEDWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -22,14 +23,26 @@ import javafx.scene.paint.Color;
  */
 public class LEDRepresentation extends BaseLEDRepresentation<LEDWidget>
 {
+    private final UntypedWidgetPropertyListener configChangedListener = this::configChanged;
+
     @Override
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propOffColor().addUntypedPropertyListener(this::configChanged);
-        model_widget.propOnColor().addUntypedPropertyListener(this::configChanged);
-        model_widget.propOffLabel().addUntypedPropertyListener(this::configChanged);
-        model_widget.propOnLabel().addUntypedPropertyListener(this::configChanged);
+        model_widget.propOffColor().addUntypedPropertyListener(configChangedListener);
+        model_widget.propOnColor().addUntypedPropertyListener(configChangedListener);
+        model_widget.propOffLabel().addUntypedPropertyListener(configChangedListener);
+        model_widget.propOnLabel().addUntypedPropertyListener(configChangedListener);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propOffColor().removePropertyListener(configChangedListener);
+        model_widget.propOnColor().removePropertyListener(configChangedListener);
+        model_widget.propOffLabel().removePropertyListener(configChangedListener);
+        model_widget.propOnLabel().removePropertyListener(configChangedListener);
+        super.unregisterListeners();
     }
 
     @Override

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/LabelRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/LabelRepresentation.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.representation.javafx.widgets;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.properties.RotationStep;
 import org.csstudio.display.builder.model.widgets.LabelWidget;
@@ -35,6 +36,9 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
     private final DirtyFlag dirty_content = new DirtyFlag();
     private volatile Pos pos;
 
+    private final UntypedWidgetPropertyListener contentChangedListener = this::contentChanged;
+    private final UntypedWidgetPropertyListener styleChangedListener = this::styleChanged;
+
     /** Was there ever any transformation applied to the jfx_node?
      *
      *  <p>Used to optimize:
@@ -57,21 +61,43 @@ public class LabelRepresentation extends RegionBaseRepresentation<Label, LabelWi
         super.registerListeners();
         pos = JFXUtil.computePos(model_widget.propHorizontalAlignment().getValue(),
                                  model_widget.propVerticalAlignment().getValue());
-        model_widget.propWidth().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propHorizontalAlignment().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propVerticalAlignment().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propRotationStep().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propWrapWords().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propWidth().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propHorizontalAlignment().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propVerticalAlignment().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propRotationStep().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propWrapWords().addUntypedPropertyListener(styleChangedListener);
 
         // Changing the text might require a resize,
         // so handle those properties together.
-        model_widget.propText().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propAutoSize().addUntypedPropertyListener(this::contentChanged);
+        model_widget.propText().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propAutoSize().addUntypedPropertyListener(contentChangedListener);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(styleChangedListener);
+        model_widget.propHeight().removePropertyListener(styleChangedListener);
+        model_widget.propForegroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propBackgroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propTransparent().removePropertyListener(styleChangedListener);
+        model_widget.propFont().removePropertyListener(styleChangedListener);
+        model_widget.propHorizontalAlignment().removePropertyListener(styleChangedListener);
+        model_widget.propVerticalAlignment().removePropertyListener(styleChangedListener);
+        model_widget.propRotationStep().removePropertyListener(styleChangedListener);
+        model_widget.propWrapWords().removePropertyListener(styleChangedListener);
+
+        // Changing the text might require a resize,
+        // so handle those properties together.
+        model_widget.propText().removePropertyListener(contentChangedListener);
+        model_widget.propAutoSize().removePropertyListener(contentChangedListener);
+
+        super.unregisterListeners();
     }
 
     private void styleChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/LinearMeterRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/LinearMeterRepresentation.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.LinearMeterWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -31,11 +32,13 @@ import javafx.scene.paint.Color;
  */
 public class LinearMeterRepresentation extends BaseMeterRepresentation<LinearMeterWidget> {
 
-    private final DirtyFlag               dirtyLimits    = new DirtyFlag();
-    private final DirtyFlag               dirtyLook      = new DirtyFlag();
-    private LinearMeterWidget.Orientation orientation    = null;
-    private volatile boolean              updatingAreas  = false;
-    private volatile boolean              zonesHighlight = true;
+    private final DirtyFlag                     dirtyLimits           = new DirtyFlag();
+    private final DirtyFlag                     dirtyLook             = new DirtyFlag();
+    private final UntypedWidgetPropertyListener limitsChangedListener = this::limitsChanged;
+    private final UntypedWidgetPropertyListener lookChangedListener   = this::lookChanged;
+    private LinearMeterWidget.Orientation       orientation           = null;
+    private volatile boolean                    updatingAreas         = false;
+    private volatile boolean                    zonesHighlight        = true;
 
     @Override
     public void updateChanges ( ) {
@@ -156,11 +159,24 @@ public class LinearMeterRepresentation extends BaseMeterRepresentation<LinearMet
 
         super.registerListeners();
 
-        model_widget.propBarColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propFlatBar().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propOrientation().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propBarColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propFlatBar().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propOrientation().addUntypedPropertyListener(lookChangedListener);
 
-        model_widget.propHighlightZones().addUntypedPropertyListener(this::limitsChanged);
+        model_widget.propHighlightZones().addUntypedPropertyListener(limitsChangedListener);
+
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        model_widget.propBarColor().removePropertyListener(lookChangedListener);
+        model_widget.propFlatBar().removePropertyListener(lookChangedListener);
+        model_widget.propOrientation().removePropertyListener(lookChangedListener);
+
+        model_widget.propHighlightZones().removePropertyListener(limitsChangedListener);
+
+        super.unregisterListeners();
 
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/MeterRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/MeterRepresentation.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.MeterWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -35,11 +36,13 @@ import javafx.scene.paint.Color;
  */
 public class MeterRepresentation extends BaseMeterRepresentation<MeterWidget> {
 
-    private final DirtyFlag          dirtyLimits    = new DirtyFlag();
-    private final DirtyFlag          dirtyLook      = new DirtyFlag();
-    private MeterWidget.Skin         skin           = null;
-    private MeterWidget.KnobPosition knobPosition   = null;
-    private volatile boolean         zonesHighlight = true;
+    private final DirtyFlag                     dirtyLimits           = new DirtyFlag();
+    private final DirtyFlag                     dirtyLook             = new DirtyFlag();
+    private final UntypedWidgetPropertyListener limitsChangedListener = this::limitsChanged;
+    private final UntypedWidgetPropertyListener lookChangedListener   = this::lookChanged;
+    private MeterWidget.KnobPosition            knobPosition          = null;
+    private MeterWidget.Skin                    skin                  = null;
+    private volatile boolean                    zonesHighlight        = true;
 
     @Override
     public void updateChanges ( ) {
@@ -359,23 +362,48 @@ public class MeterRepresentation extends BaseMeterRepresentation<MeterWidget> {
 
         super.registerListeners();
 
-        model_widget.propAverage().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propAverageColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propAverageSamples().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propKnobColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propKnobPosition().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propMajorTickVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propMediumTickVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propMinorTickVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propNeedleColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propOnlyExtremaVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propScaleDirection().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propSkin().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTickLabelDecimals().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTickLabelsVisible().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTickMarkRingVisible().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propAverage().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propAverageColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propAverageSamples().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propKnobColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propKnobPosition().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propMajorTickVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propMediumTickVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propMinorTickVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propNeedleColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propOnlyExtremaVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propScaleDirection().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propSkin().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTickLabelDecimals().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTickLabelsVisible().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTickMarkRingVisible().addUntypedPropertyListener(lookChangedListener);
 
-        model_widget.propHighlightZones().addUntypedPropertyListener(this::limitsChanged);
+        model_widget.propHighlightZones().addUntypedPropertyListener(limitsChangedListener);
+
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        model_widget.propAverage().removePropertyListener(lookChangedListener);
+        model_widget.propAverageColor().removePropertyListener(lookChangedListener);
+        model_widget.propAverageSamples().removePropertyListener(lookChangedListener);
+        model_widget.propKnobColor().removePropertyListener(lookChangedListener);
+        model_widget.propKnobPosition().removePropertyListener(lookChangedListener);
+        model_widget.propMajorTickVisible().removePropertyListener(lookChangedListener);
+        model_widget.propMediumTickVisible().removePropertyListener(lookChangedListener);
+        model_widget.propMinorTickVisible().removePropertyListener(lookChangedListener);
+        model_widget.propNeedleColor().removePropertyListener(lookChangedListener);
+        model_widget.propOnlyExtremaVisible().removePropertyListener(lookChangedListener);
+        model_widget.propScaleDirection().removePropertyListener(lookChangedListener);
+        model_widget.propSkin().removePropertyListener(lookChangedListener);
+        model_widget.propTickLabelDecimals().removePropertyListener(lookChangedListener);
+        model_widget.propTickLabelsVisible().removePropertyListener(lookChangedListener);
+        model_widget.propTickMarkRingVisible().removePropertyListener(lookChangedListener);
+
+        model_widget.propHighlightZones().removePropertyListener(limitsChangedListener);
+
+        super.unregisterListeners();
 
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/MultiStateLEDRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/MultiStateLEDRepresentation.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.MultiStateLEDWidget;
 import org.csstudio.display.builder.model.widgets.MultiStateLEDWidget.StateWidgetProperty;
@@ -25,14 +26,24 @@ import javafx.scene.paint.Color;
 public class MultiStateLEDRepresentation extends BaseLEDRepresentation<MultiStateLEDWidget>
 {
     private final UntypedWidgetPropertyListener state_listener = (prop, old, value) -> configChanged(prop, old, value);
+    private final WidgetPropertyListener<List<StateWidgetProperty>> statesChangedListener = this::statesChanged;
 
     @Override
     protected void registerListeners()
     {
         super.registerListeners();
         // Track changes to (most of) the state details
-        model_widget.propStates().addPropertyListener(this::statesChanged);
+        model_widget.propStates().addPropertyListener(statesChangedListener);
         statesChanged(null, null, model_widget.propStates().getValue());
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        // Track changes to (most of) the state details
+        model_widget.propStates().removePropertyListener(statesChangedListener);
+        statesChanged(null, model_widget.propStates().getValue(), null);
+        super.unregisterListeners();
     }
 
     private void statesChanged(final WidgetProperty<List<StateWidgetProperty>> prop,

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/NavigationTabsRepresentation.java
@@ -101,6 +101,11 @@ public class NavigationTabsRepresentation extends RegionBaseRepresentation<Navig
         ModelThreadPool.getExecutor().execute(this::updatePendingDisplay);
     };
 
+    private final UntypedWidgetPropertyListener sizesChangedListener = this::sizesChanged;
+    private final UntypedWidgetPropertyListener tabLookChangedListener = this::tabLookChanged;
+    private final WidgetPropertyListener<Integer> activeTabChangedListener = this::activeTabChanged;
+    private final WidgetPropertyListener<List<TabProperty>> tabsChangedListener = this::tabsChanged;
+
     @Override
     public NavigationTabs createJFXNode() throws Exception
     {
@@ -127,24 +132,45 @@ public class NavigationTabsRepresentation extends RegionBaseRepresentation<Navig
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::sizesChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::sizesChanged);
+        model_widget.propWidth().addUntypedPropertyListener(sizesChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(sizesChangedListener);
 
-        model_widget.propDirection().addPropertyListener(this::tabLookChanged);
-        model_widget.propTabWidth().addPropertyListener(this::tabLookChanged);
-        model_widget.propTabHeight().addPropertyListener(this::tabLookChanged);
-        model_widget.propTabSpacing().addPropertyListener(this::tabLookChanged);
-        model_widget.propSelectedColor().addPropertyListener(this::tabLookChanged);
-        model_widget.propDeselectedColor().addPropertyListener(this::tabLookChanged);
-        model_widget.propFont().addPropertyListener(this::tabLookChanged);
+        model_widget.propDirection().addUntypedPropertyListener(tabLookChangedListener);
+        model_widget.propTabWidth().addUntypedPropertyListener(tabLookChangedListener);
+        model_widget.propTabHeight().addUntypedPropertyListener(tabLookChangedListener);
+        model_widget.propTabSpacing().addUntypedPropertyListener(tabLookChangedListener);
+        model_widget.propSelectedColor().addUntypedPropertyListener(tabLookChangedListener);
+        model_widget.propDeselectedColor().addUntypedPropertyListener(tabLookChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(tabLookChangedListener);
 
-        model_widget.propActiveTab().addPropertyListener(this::activeTabChanged);
+        model_widget.propActiveTab().addPropertyListener(activeTabChangedListener);
 
-        model_widget.propTabs().addPropertyListener(this::tabsChanged);
+        model_widget.propTabs().addPropertyListener(tabsChangedListener);
 
         // Initial update
         tabsChanged(model_widget.propTabs(), null, model_widget.propTabs().getValue());
         activeTabChanged(null, null, model_widget.propActiveTab().getValue());
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(sizesChangedListener);
+        model_widget.propHeight().removePropertyListener(sizesChangedListener);
+
+        model_widget.propDirection().removePropertyListener(tabLookChangedListener);
+        model_widget.propTabWidth().removePropertyListener(tabLookChangedListener);
+        model_widget.propTabHeight().removePropertyListener(tabLookChangedListener);
+        model_widget.propTabSpacing().removePropertyListener(tabLookChangedListener);
+        model_widget.propSelectedColor().removePropertyListener(tabLookChangedListener);
+        model_widget.propDeselectedColor().removePropertyListener(tabLookChangedListener);
+        model_widget.propFont().removePropertyListener(tabLookChangedListener);
+
+        model_widget.propActiveTab().removePropertyListener(activeTabChangedListener);
+
+        model_widget.propTabs().removePropertyListener(tabsChangedListener);
+
+        super.unregisterListeners();
     }
 
     private void activeTabChanged(final WidgetProperty<Integer> property, final Integer old_index, final Integer tab_index)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PolygonRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PolygonRepresentation.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.representation.javafx.widgets;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.PolygonWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -22,6 +23,7 @@ import javafx.scene.shape.StrokeLineJoin;
 public class PolygonRepresentation extends JFXBaseRepresentation<Polygon, PolygonWidget>
 {
     private final DirtyFlag dirty_display = new DirtyFlag();
+    private final UntypedWidgetPropertyListener displayChangedListener = this::displayChanged;
 
     @Override
     public Polygon createJFXNode() throws Exception
@@ -39,14 +41,31 @@ public class PolygonRepresentation extends JFXBaseRepresentation<Polygon, Polygo
         // ==> Tooltip must be attached explicitly.
         if (! toolkit.isEditMode())
             attachTooltip();
-        // ==> Visibility and position nust be handled explicitly.
-        model_widget.propVisible().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propX().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propY().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propLineColor().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propLineWidth().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propPoints().addUntypedPropertyListener(this::displayChanged);
+        // ==> Visibility and position must be handled explicitly.
+        model_widget.propVisible().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propX().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propY().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propLineColor().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propLineWidth().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propPoints().addUntypedPropertyListener(displayChangedListener);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        // Polygon can't use the default x/y handling from super.unregisterListeners();
+        // ==> Tooltip must be attached explicitly.
+        if (! toolkit.isEditMode())
+            detachTooltip();
+        // ==> Visibility and position must be handled explicitly.
+        model_widget.propVisible().removePropertyListener(displayChangedListener);
+        model_widget.propX().removePropertyListener(displayChangedListener);
+        model_widget.propY().removePropertyListener(displayChangedListener);
+        model_widget.propBackgroundColor().removePropertyListener(displayChangedListener);
+        model_widget.propLineColor().removePropertyListener(displayChangedListener);
+        model_widget.propLineWidth().removePropertyListener(displayChangedListener);
+        model_widget.propPoints().removePropertyListener(displayChangedListener);
     }
 
     private void displayChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PolylineRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/PolylineRepresentation.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.PolylineWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -31,6 +32,7 @@ import javafx.scene.shape.StrokeLineJoin;
 public class PolylineRepresentation extends JFXBaseRepresentation<Group, PolylineWidget>
 {
     private final DirtyFlag dirty_display = new DirtyFlag();
+    private final UntypedWidgetPropertyListener displayChangedListener = this::displayChanged;
 
     @Override
     public Group createJFXNode() throws Exception
@@ -83,15 +85,34 @@ public class PolylineRepresentation extends JFXBaseRepresentation<Group, Polylin
         if (! toolkit.isEditMode())
             attachTooltip();
         // ==> Visibility and position nust be handled explicitly.
-        model_widget.propVisible().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propX().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propY().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propLineColor().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propLineWidth().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propLineStyle().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propPoints().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propArrows().addUntypedPropertyListener(this::displayChanged);
-        model_widget.propArrowLength().addUntypedPropertyListener(this::displayChanged);
+        model_widget.propVisible().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propX().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propY().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propLineColor().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propLineWidth().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propLineStyle().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propPoints().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propArrows().addUntypedPropertyListener(displayChangedListener);
+        model_widget.propArrowLength().addUntypedPropertyListener(displayChangedListener);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        // Polyline can't use the default x/y handling from super.unregisterListeners();
+        // ==> Tooltip must be attached explicitly.
+        if (! toolkit.isEditMode())
+            detachTooltip();
+        // ==> Visibility and position must be handled explicitly.
+        model_widget.propVisible().removePropertyListener(displayChangedListener);
+        model_widget.propX().removePropertyListener(displayChangedListener);
+        model_widget.propY().removePropertyListener(displayChangedListener);
+        model_widget.propLineColor().removePropertyListener(displayChangedListener);
+        model_widget.propLineWidth().removePropertyListener(displayChangedListener);
+        model_widget.propLineStyle().removePropertyListener(displayChangedListener);
+        model_widget.propPoints().removePropertyListener(displayChangedListener);
+        model_widget.propArrows().removePropertyListener(displayChangedListener);
+        model_widget.propArrowLength().removePropertyListener(displayChangedListener);
     }
 
     private void displayChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ProgressBarRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ProgressBarRepresentation.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.representation.javafx.widgets;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.ProgressBarWidget;
@@ -31,6 +32,9 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Progress
     private final DirtyFlag dirty_value = new DirtyFlag();
     private volatile double percentage = 0.0;
 
+    private final UntypedWidgetPropertyListener lookChangedListener = this::lookChanged;
+    private final UntypedWidgetPropertyListener valueChangedListener = this::valueChanged;
+
     @Override
     public ProgressBar createJFXNode() throws Exception
     {
@@ -42,15 +46,29 @@ public class ProgressBarRepresentation extends RegionBaseRepresentation<Progress
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propFillColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propWidth().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLimitsFromPV().addUntypedPropertyListener(this::valueChanged);
-        model_widget.propMinimum().addUntypedPropertyListener(this::valueChanged);
-        model_widget.propMaximum().addUntypedPropertyListener(this::valueChanged);
-        model_widget.runtimePropValue().addUntypedPropertyListener(this::valueChanged);
-        model_widget.propHorizontal().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propFillColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propWidth().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLimitsFromPV().addUntypedPropertyListener(valueChangedListener);
+        model_widget.propMinimum().addUntypedPropertyListener(valueChangedListener);
+        model_widget.propMaximum().addUntypedPropertyListener(valueChangedListener);
+        model_widget.runtimePropValue().addUntypedPropertyListener(valueChangedListener);
+        model_widget.propHorizontal().addUntypedPropertyListener(lookChangedListener);
         valueChanged(null, null, null);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propFillColor().removePropertyListener(lookChangedListener);
+        model_widget.propWidth().removePropertyListener(lookChangedListener);
+        model_widget.propHeight().removePropertyListener(lookChangedListener);
+        model_widget.propLimitsFromPV().removePropertyListener(valueChangedListener);
+        model_widget.propMinimum().removePropertyListener(valueChangedListener);
+        model_widget.propMaximum().removePropertyListener(valueChangedListener);
+        model_widget.runtimePropValue().removePropertyListener(valueChangedListener);
+        model_widget.propHorizontal().removePropertyListener(lookChangedListener);
+        super.unregisterListeners();
     }
 
     private void lookChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/RadioRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/RadioRepresentation.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.properties.FormatOption;
 import org.csstudio.display.builder.model.util.FormatOptionHandler;
@@ -27,6 +28,7 @@ import org.diirt.vtype.VType;
 import org.diirt.vtype.next.VNumber;
 
 import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
@@ -54,6 +56,11 @@ public class RadioRepresentation extends JFXBaseRepresentation<TilePane, RadioWi
     private volatile int index = -1;
     protected volatile boolean enabled = true;
 
+    private final UntypedWidgetPropertyListener contentChangedListener = this::contentChanged;
+    private final UntypedWidgetPropertyListener sizeChangedListener = this::sizeChanged;
+    private final UntypedWidgetPropertyListener styleChangedListener = this::styleChanged;
+    private final ChangeListener<Toggle> selectionChangedListener = this::selectionChanged;
+
     @Override
     public TilePane createJFXNode() throws Exception
     {
@@ -74,24 +81,46 @@ public class RadioRepresentation extends JFXBaseRepresentation<TilePane, RadioWi
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::sizeChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::sizeChanged);
-        model_widget.propHorizontal().addUntypedPropertyListener(this::sizeChanged);
+        model_widget.propWidth().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propHorizontal().addUntypedPropertyListener(sizeChangedListener);
 
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
-        model_widget.runtimePropPVWritable().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propForegroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propEnabled().addUntypedPropertyListener(styleChangedListener);
+        model_widget.runtimePropPVWritable().addUntypedPropertyListener(styleChangedListener);
 
-        model_widget.runtimePropValue().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propItemsFromPV().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propItems().addUntypedPropertyListener(this::contentChanged);
+        model_widget.runtimePropValue().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propItemsFromPV().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propItems().addUntypedPropertyListener(contentChangedListener);
 
         if (! toolkit.isEditMode())
-            toggle.selectedToggleProperty().addListener(this::selectionChanged);
+            toggle.selectedToggleProperty().addListener(selectionChangedListener);
 
         // Initially populate pane with radio buttons
         contentChanged(null, null, null);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(sizeChangedListener);
+        model_widget.propHeight().removePropertyListener(sizeChangedListener);
+        model_widget.propHorizontal().removePropertyListener(sizeChangedListener);
+
+        model_widget.propForegroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propFont().removePropertyListener(styleChangedListener);
+        model_widget.propEnabled().removePropertyListener(styleChangedListener);
+        model_widget.runtimePropPVWritable().removePropertyListener(styleChangedListener);
+
+        model_widget.runtimePropValue().removePropertyListener(contentChangedListener);
+        model_widget.propItemsFromPV().removePropertyListener(contentChangedListener);
+        model_widget.propItems().removePropertyListener(contentChangedListener);
+
+        if (! toolkit.isEditMode())
+            toggle.selectedToggleProperty().removeListener(selectionChangedListener);
+
+        super.unregisterListeners();
     }
 
     @Override

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/RectangleRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/RectangleRepresentation.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.representation.javafx.widgets;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.widgets.RectangleWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -25,6 +26,8 @@ public class RectangleRepresentation extends JFXBaseRepresentation<Rectangle, Re
     private final DirtyFlag dirty_look = new DirtyFlag();
     private volatile Color background, line_color;
     private volatile boolean ignore_mouse = false;
+    private final UntypedWidgetPropertyListener lookChangedListener = this::lookChanged;
+    private final UntypedWidgetPropertyListener sizeChangedListener = this::sizeChanged;
 
     @Override
     public Rectangle createJFXNode() throws Exception
@@ -38,16 +41,32 @@ public class RectangleRepresentation extends JFXBaseRepresentation<Rectangle, Re
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::sizeChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::sizeChanged);
-        model_widget.propCornerWidth().addUntypedPropertyListener(this::sizeChanged);
-        model_widget.propCornerHeight().addUntypedPropertyListener(this::sizeChanged);
+        model_widget.propWidth().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propCornerWidth().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propCornerHeight().addUntypedPropertyListener(sizeChangedListener);
 
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLineColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLineWidth().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLineColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLineWidth().addUntypedPropertyListener(lookChangedListener);
    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(sizeChangedListener);
+        model_widget.propHeight().removePropertyListener(sizeChangedListener);
+        model_widget.propCornerWidth().removePropertyListener(sizeChangedListener);
+        model_widget.propCornerHeight().removePropertyListener(sizeChangedListener);
+
+        model_widget.propBackgroundColor().removePropertyListener(lookChangedListener);
+        model_widget.propTransparent().removePropertyListener(lookChangedListener);
+        model_widget.propLineColor().removePropertyListener(lookChangedListener);
+        model_widget.propLineWidth().removePropertyListener(lookChangedListener);
+
+        super.unregisterListeners();
+    }
 
     private void sizeChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
     {

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ScaledSliderRepresentation.java
@@ -10,10 +10,13 @@ package org.csstudio.display.builder.representation.javafx.widgets;
 import static org.csstudio.display.builder.representation.ToolkitRepresentation.logger;
 
 import java.text.DecimalFormat;
+import java.time.Instant;
 import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.ScaledSliderWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -21,6 +24,7 @@ import org.diirt.vtype.Display;
 import org.diirt.vtype.VType;
 import org.diirt.vtype.ValueUtil;
 
+import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
@@ -63,6 +67,13 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
 
     private final Slider slider = new Slider();
     private final SliderMarkers markers = new SliderMarkers(slider);
+
+    private final UntypedWidgetPropertyListener layoutChangedListener = this::layoutChanged;
+    private final UntypedWidgetPropertyListener limitsChangedListener = this::limitsChanged;
+    private final WidgetPropertyListener<Boolean> enablementChangedListener = this::enablementChanged;
+    private final WidgetPropertyListener<Instant> runtimeConfChangedListener = (p, o, n) -> openConfigurationPanel();
+    private final WidgetPropertyListener<VType> valueChangedListener = this::valueChanged;
+    private final ChangeListener<? super Number> sliderMoveListener = this::handleSliderMove;
 
     @Override
     protected GridPane createJFXNode() throws Exception
@@ -110,48 +121,92 @@ public class ScaledSliderRepresentation extends RegionBaseRepresentation<GridPan
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::layoutChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::layoutChanged);
-        model_widget.propHorizontal().addUntypedPropertyListener(this::layoutChanged);
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::layoutChanged);
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::layoutChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::layoutChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::layoutChanged);
-        model_widget.propShowScale().addUntypedPropertyListener(this::layoutChanged);
-        model_widget.propScaleFormat().addUntypedPropertyListener(this::layoutChanged);
-        model_widget.propShowMinorTicks().addUntypedPropertyListener(this::layoutChanged);
-        model_widget.propIncrement().addPropertyListener(this::layoutChanged);
+        model_widget.propWidth().addUntypedPropertyListener(layoutChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(layoutChangedListener);
+        model_widget.propHorizontal().addUntypedPropertyListener(layoutChangedListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(layoutChangedListener);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(layoutChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(layoutChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(layoutChangedListener);
+        model_widget.propShowScale().addUntypedPropertyListener(layoutChangedListener);
+        model_widget.propScaleFormat().addUntypedPropertyListener(layoutChangedListener);
+        model_widget.propShowMinorTicks().addUntypedPropertyListener(layoutChangedListener);
+        model_widget.propIncrement().addUntypedPropertyListener(layoutChangedListener);
 
-        model_widget.propEnabled().addPropertyListener(this::enablementChanged);
-        model_widget.runtimePropPVWritable().addPropertyListener(this::enablementChanged);
+        model_widget.propEnabled().addPropertyListener(enablementChangedListener);
+        model_widget.runtimePropPVWritable().addPropertyListener(enablementChangedListener);
 
-        model_widget.propLevelHi().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLevelHiHi().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLevelLo().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLevelLoLo().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowHigh().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowHiHi().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowLow().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propShowLoLo().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propMinimum().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propMaximum().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propMajorTickStepHint().addUntypedPropertyListener(this::limitsChanged);
-        model_widget.propLimitsFromPV().addUntypedPropertyListener(this::limitsChanged);
+        model_widget.propLevelHi().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLevelHiHi().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLevelLo().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLevelLoLo().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowHigh().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowHiHi().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowLow().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propShowLoLo().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propMinimum().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propMaximum().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propMajorTickStepHint().addUntypedPropertyListener(limitsChangedListener);
+        model_widget.propLimitsFromPV().addUntypedPropertyListener(limitsChangedListener);
 
 
         // Since both the widget's PV value and the JFX node's value property might be
         // written to independently during runtime, both must have listeners.
-        slider.valueProperty().addListener(this::handleSliderMove);
+        slider.valueProperty().addListener(sliderMoveListener);
         if (toolkit.isEditMode())
             dirty_value.checkAndClear();
         else
         {
-            model_widget.runtimePropValue().addPropertyListener(this::valueChanged);
-            model_widget.runtimePropConfigure().addPropertyListener((p, o, n) -> openConfigurationPanel());
+            model_widget.runtimePropValue().addPropertyListener(valueChangedListener);
+            model_widget.runtimePropConfigure().addPropertyListener(runtimeConfChangedListener);
         }
         enablementChanged(null, null, null);
         limitsChanged(null, null, null);
         layoutChanged(null, null, null);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(layoutChangedListener);
+        model_widget.propHeight().removePropertyListener(layoutChangedListener);
+        model_widget.propHorizontal().removePropertyListener(layoutChangedListener);
+        model_widget.propForegroundColor().removePropertyListener(layoutChangedListener);
+        model_widget.propBackgroundColor().removePropertyListener(layoutChangedListener);
+        model_widget.propTransparent().removePropertyListener(layoutChangedListener);
+        model_widget.propFont().removePropertyListener(layoutChangedListener);
+        model_widget.propShowScale().removePropertyListener(layoutChangedListener);
+        model_widget.propScaleFormat().removePropertyListener(layoutChangedListener);
+        model_widget.propShowMinorTicks().removePropertyListener(layoutChangedListener);
+        model_widget.propIncrement().removePropertyListener(layoutChangedListener);
+
+        model_widget.propEnabled().removePropertyListener(enablementChangedListener);
+        model_widget.runtimePropPVWritable().removePropertyListener(enablementChangedListener);
+
+        model_widget.propLevelHi().removePropertyListener(limitsChangedListener);
+        model_widget.propLevelHiHi().removePropertyListener(limitsChangedListener);
+        model_widget.propLevelLo().removePropertyListener(limitsChangedListener);
+        model_widget.propLevelLoLo().removePropertyListener(limitsChangedListener);
+        model_widget.propShowHigh().removePropertyListener(limitsChangedListener);
+        model_widget.propShowHiHi().removePropertyListener(limitsChangedListener);
+        model_widget.propShowLow().removePropertyListener(limitsChangedListener);
+        model_widget.propShowLoLo().removePropertyListener(limitsChangedListener);
+        model_widget.propMinimum().removePropertyListener(limitsChangedListener);
+        model_widget.propMaximum().removePropertyListener(limitsChangedListener);
+        model_widget.propMajorTickStepHint().removePropertyListener(limitsChangedListener);
+        model_widget.propLimitsFromPV().removePropertyListener(limitsChangedListener);
+
+
+        // Since both the widget's PV value and the JFX node's value property might be
+        // written to independently during runtime, both must have listeners.
+        slider.valueProperty().removeListener(sliderMoveListener);
+        if ( !toolkit.isEditMode() )
+        {
+            model_widget.runtimePropValue().removePropertyListener(valueChangedListener);
+            model_widget.runtimePropConfigure().removePropertyListener(runtimeConfChangedListener);
+        }
+
+        super.unregisterListeners();
     }
 
     private void layoutChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SlideButtonRepresentation.java
@@ -16,7 +16,9 @@ import java.util.logging.Level;
 
 import org.controlsfx.control.ToggleSwitch;
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.SlideButtonWidget;
 import org.csstudio.display.builder.representation.javafx.JFXUtil;
@@ -61,6 +63,12 @@ public class SlideButtonRepresentation extends RegionBaseRepresentation<HBox, Sl
     private volatile String state_colors;
 
     private volatile AtomicBoolean updating = new AtomicBoolean();
+
+    private final UntypedWidgetPropertyListener   sizeChangedListener  = this::sizeChanged;
+    private final UntypedWidgetPropertyListener   styleChangedListener = this::styleChanged;
+    private final WidgetPropertyListener<Integer> bitChangedListener   = this::bitChanged;
+    private final WidgetPropertyListener<String>  labelChangedListener = this::labelChanged;
+    private final WidgetPropertyListener<VType>   valueChangedListener = this::valueChanged;
 
     @Override
     public HBox createJFXNode ( ) throws Exception {
@@ -145,30 +153,53 @@ public class SlideButtonRepresentation extends RegionBaseRepresentation<HBox, Sl
 
         super.registerListeners();
 
-        model_widget.propAutoSize().addUntypedPropertyListener(this::sizeChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::sizeChanged);
-        model_widget.propWidth().addUntypedPropertyListener(this::sizeChanged);
+        model_widget.propAutoSize().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propWidth().addUntypedPropertyListener(sizeChangedListener);
 
         labelChanged(model_widget.propLabel(), null, model_widget.propLabel().getValue());
 
-        model_widget.propLabel().addPropertyListener(this::labelChanged);
+        model_widget.propLabel().addPropertyListener(labelChangedListener);
 
         styleChanged(null, null, null);
 
-        model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propOffColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propOnColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.runtimePropPVWritable().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propEnabled().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propOffColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propOnColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.runtimePropPVWritable().addUntypedPropertyListener(styleChangedListener);
 
         bitChanged(model_widget.propBit(), null, model_widget.propBit().getValue());
 
-        model_widget.propBit().addPropertyListener(this::bitChanged);
-        model_widget.runtimePropValue().addPropertyListener(this::valueChanged);
+        model_widget.propBit().addPropertyListener(bitChangedListener);
+        model_widget.runtimePropValue().addPropertyListener(valueChangedListener);
 
         // Initial Update
         valueChanged(null, null, model_widget.runtimePropValue().getValue());
+
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        model_widget.propAutoSize().removePropertyListener(sizeChangedListener);
+        model_widget.propHeight().removePropertyListener(sizeChangedListener);
+        model_widget.propWidth().removePropertyListener(sizeChangedListener);
+
+        model_widget.propLabel().removePropertyListener(labelChangedListener);
+
+        model_widget.propEnabled().removePropertyListener(styleChangedListener);
+        model_widget.propFont().removePropertyListener(styleChangedListener);
+        model_widget.propForegroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propOffColor().removePropertyListener(styleChangedListener);
+        model_widget.propOnColor().removePropertyListener(styleChangedListener);
+        model_widget.runtimePropPVWritable().removePropertyListener(styleChangedListener);
+
+        model_widget.propBit().removePropertyListener(bitChangedListener);
+        model_widget.runtimePropValue().removePropertyListener(valueChangedListener);
+
+        super.unregisterListeners();
 
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
@@ -12,6 +12,7 @@ import static org.csstudio.display.builder.representation.ToolkitRepresentation.
 import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.util.FormatOptionHandler;
 import org.csstudio.display.builder.model.widgets.SpinnerWidget;
@@ -54,6 +55,10 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<Stri
     protected volatile VType  value      = null;
     private volatile double   value_max  = 100.0;
     private volatile double   value_min  = 0.0;
+
+    private final UntypedWidgetPropertyListener behaviorChangedListener = this::behaviorChanged;
+    private final UntypedWidgetPropertyListener contentChangedListener = this::contentChanged;
+    private final UntypedWidgetPropertyListener styleChangedListener = this::styleChanged;
 
     @Override
     protected final Spinner<String> createJFXNode() throws Exception
@@ -324,26 +329,50 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<Stri
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propButtonsOnLeft().addPropertyListener(this::styleChanged);
+        model_widget.propWidth().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propButtonsOnLeft().addUntypedPropertyListener(styleChangedListener);
 
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propForegroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propEnabled().addUntypedPropertyListener(styleChangedListener);
 
-        model_widget.propIncrement().addUntypedPropertyListener(this::behaviorChanged);
-        model_widget.propMinimum().addUntypedPropertyListener(this::behaviorChanged);
-        model_widget.propMaximum().addUntypedPropertyListener(this::behaviorChanged);
-        model_widget.propLimitsFromPV().addUntypedPropertyListener(this::behaviorChanged);
+        model_widget.propIncrement().addUntypedPropertyListener(behaviorChangedListener);
+        model_widget.propMinimum().addUntypedPropertyListener(behaviorChangedListener);
+        model_widget.propMaximum().addUntypedPropertyListener(behaviorChangedListener);
+        model_widget.propLimitsFromPV().addUntypedPropertyListener(behaviorChangedListener);
 
-        model_widget.propFormat().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propPrecision().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propShowUnits().addUntypedPropertyListener(this::contentChanged);
-        model_widget.runtimePropValue().addUntypedPropertyListener(this::contentChanged);
+        model_widget.propFormat().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propPrecision().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propShowUnits().addUntypedPropertyListener(contentChangedListener);
+        model_widget.runtimePropValue().addUntypedPropertyListener(contentChangedListener);
 
         behaviorChanged(null, null, null);
         contentChanged(null, null, null);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(styleChangedListener);
+        model_widget.propHeight().removePropertyListener(styleChangedListener);
+        model_widget.propButtonsOnLeft().removePropertyListener(styleChangedListener);
+
+        model_widget.propForegroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propBackgroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propEnabled().removePropertyListener(styleChangedListener);
+
+        model_widget.propIncrement().removePropertyListener(behaviorChangedListener);
+        model_widget.propMinimum().removePropertyListener(behaviorChangedListener);
+        model_widget.propMaximum().removePropertyListener(behaviorChangedListener);
+        model_widget.propLimitsFromPV().removePropertyListener(behaviorChangedListener);
+
+        model_widget.propFormat().removePropertyListener(contentChangedListener);
+        model_widget.propPrecision().removePropertyListener(contentChangedListener);
+        model_widget.propShowUnits().removePropertyListener(contentChangedListener);
+        model_widget.runtimePropValue().removePropertyListener(contentChangedListener);
+
+        super.unregisterListeners();
     }
 
     @Override

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SymbolRepresentation.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.csstudio.display.builder.model.ArrayWidgetProperty;
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.macros.MacroHandler;
@@ -83,23 +84,29 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
 
     private static final double INDEX_LABEL_SIZE = 32.0;
 
-    private int                                  arrayIndex             = 0;
-    private volatile boolean                     autoSize               = false;
-    private Symbol                               symbol;
-    private final Symbol                         defaultSymbol;
-    private final DefaultSymbolNode              defaultSymbolNode      = new DefaultSymbolNode();
-    private final DirtyFlag                      dirtyContent           = new DirtyFlag();
-    private final DirtyFlag                      dirtyGeometry          = new DirtyFlag();
-    private final DirtyFlag                      dirtyStyle             = new DirtyFlag();
-    private final DirtyFlag                      dirtyValue             = new DirtyFlag();
-    private volatile boolean                     enabled                = true;
-    private final ImageView                      imageView              = new ImageView();
-    private final Label                          indexLabel             = new Label();
-    private final Circle                         indexLabelBackground   = new Circle(INDEX_LABEL_SIZE / 2, Color.BLACK.deriveColor(0.0, 0.0, 0.0, 0.75));
-    private Dimension2D                          maxSize                = new Dimension2D(0, 0);
-    private final WidgetPropertyListener<String> symbolPropertyListener = this::symbolChanged;
-    private final AtomicReference<List<Symbol>>  symbols                = new AtomicReference<>(Collections.emptyList());
-    private final AtomicBoolean                  updatingValue          = new AtomicBoolean(false);
+    private int                                                        arrayIndex                  = 0;
+    private volatile boolean                                           autoSize                    = false;
+    private final UntypedWidgetPropertyListener                        contentChangedListener      = this::contentChanged;
+    private final Symbol                                               defaultSymbol;
+    private final DefaultSymbolNode                                    defaultSymbolNode           = new DefaultSymbolNode();
+    private final DirtyFlag                                            dirtyContent                = new DirtyFlag();
+    private final DirtyFlag                                            dirtyGeometry               = new DirtyFlag();
+    private final DirtyFlag                                            dirtyStyle                  = new DirtyFlag();
+    private final DirtyFlag                                            dirtyValue                  = new DirtyFlag();
+    private volatile boolean                                           enabled                     = true;
+    private final UntypedWidgetPropertyListener                        geometryChangedListener     = this::geometryChanged;
+    private final ImageView                                            imageView                   = new ImageView();
+    private final Label                                                indexLabel                  = new Label();
+    private final Circle                                               indexLabelBackground        = new Circle(INDEX_LABEL_SIZE / 2, Color.BLACK.deriveColor(0.0, 0.0, 0.0, 0.75));
+    private final WidgetPropertyListener<Integer>                      initialIndexChangedListener = this::initialIndexChanged;
+    private Dimension2D                                                maxSize                     = new Dimension2D(0, 0);
+    private final UntypedWidgetPropertyListener                        styleChangedListener        = this::styleChanged;
+    private Symbol                                                     symbol;
+    private final WidgetPropertyListener<String>                       symbolPropertyListener      = this::symbolChanged;
+    private final AtomicReference<List<Symbol>>                        symbols                     = new AtomicReference<>(Collections.emptyList());
+    private final WidgetPropertyListener<List<WidgetProperty<String>>> symbolsChangedListener      = this::symbolsChanged;
+    private final AtomicBoolean                                        updatingValue               = new AtomicBoolean(false);
+    private final WidgetPropertyListener<VType>                        valueChangedListener        = this::valueChanged;
 
     // ---- imageIndex property
     private IntegerProperty imageIndex = new SimpleIntegerProperty(-1);
@@ -182,8 +189,6 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
 
     @Override
     public void dispose ( ) {
-
-        model_widget.propSymbols().getValue().stream().forEach(p -> p.removePropertyListener(symbolPropertyListener));
 
         symbol = null;
 
@@ -388,34 +393,67 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
 
         super.registerListeners();
 
-        model_widget.propArrayIndex().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propPVName().addPropertyListener(this::contentChanged);
+        model_widget.propArrayIndex().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propPVName().addUntypedPropertyListener(contentChangedListener);
 
-        model_widget.propSymbols().addPropertyListener(this::symbolsChanged);
+        model_widget.propSymbols().addPropertyListener(symbolsChangedListener);
         model_widget.propSymbols().getValue().stream().forEach(p -> p.addPropertyListener(symbolPropertyListener));
 
-        model_widget.propInitialIndex().addPropertyListener(this::initialIndexChanged);
+        model_widget.propInitialIndex().addPropertyListener(initialIndexChangedListener);
 
-        model_widget.propAutoSize().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propVisible().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propX().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propY().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propWidth().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propPreserveRatio().addUntypedPropertyListener(this::geometryChanged);
-        model_widget.propRotation().addUntypedPropertyListener(this::geometryChanged);
+        model_widget.propAutoSize().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propVisible().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propX().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propY().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propWidth().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propPreserveRatio().addUntypedPropertyListener(geometryChangedListener);
+        model_widget.propRotation().addUntypedPropertyListener(geometryChangedListener);
 
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propShowIndex().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propEnabled().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propShowIndex().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(styleChangedListener);
 
         if ( toolkit.isEditMode() ) {
             dirtyValue.checkAndClear();
         } else {
-            model_widget.runtimePropValue().addPropertyListener(this::valueChanged);
+            model_widget.runtimePropValue().addPropertyListener(valueChangedListener);
             valueChanged(null, null, null);
         }
+
+    }
+
+    @Override
+    protected void unregisterListeners ( ) {
+
+        model_widget.propArrayIndex().removePropertyListener(contentChangedListener);
+        model_widget.propPVName().removePropertyListener(contentChangedListener);
+
+        model_widget.propSymbols().removePropertyListener(symbolsChangedListener);
+        model_widget.propSymbols().getValue().stream().forEach(p -> p.removePropertyListener(symbolPropertyListener));
+
+        model_widget.propInitialIndex().removePropertyListener(initialIndexChangedListener);
+
+        model_widget.propAutoSize().removePropertyListener(geometryChangedListener);
+        model_widget.propVisible().removePropertyListener(geometryChangedListener);
+        model_widget.propX().removePropertyListener(geometryChangedListener);
+        model_widget.propY().removePropertyListener(geometryChangedListener);
+        model_widget.propWidth().removePropertyListener(geometryChangedListener);
+        model_widget.propHeight().removePropertyListener(geometryChangedListener);
+        model_widget.propPreserveRatio().removePropertyListener(geometryChangedListener);
+        model_widget.propRotation().removePropertyListener(geometryChangedListener);
+
+        model_widget.propBackgroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propEnabled().removePropertyListener(styleChangedListener);
+        model_widget.propShowIndex().removePropertyListener(styleChangedListener);
+        model_widget.propTransparent().removePropertyListener(styleChangedListener);
+
+        if ( !toolkit.isEditMode() ) {
+            model_widget.runtimePropValue().removePropertyListener(valueChangedListener);
+        }
+
+        super.unregisterListeners();
 
     }
 
@@ -532,7 +570,7 @@ public class SymbolRepresentation extends RegionBaseRepresentation<StackPane, Sy
 
     }
 
-    private void initialIndexChanged ( final WidgetProperty<?> property, final Object oldValue, final Object newValue ) {
+    private void initialIndexChanged ( final WidgetProperty<Integer> property, final Object oldValue, final Object newValue ) {
         dirtyValue.mark();
         toolkit.scheduleUpdate(this);
     }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TankRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TankRepresentation.java
@@ -10,6 +10,7 @@ package org.csstudio.display.builder.representation.javafx.widgets;
 import java.util.concurrent.TimeUnit;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.TankWidget;
@@ -31,6 +32,9 @@ public class TankRepresentation extends RegionBaseRepresentation<Pane, TankWidge
 
     private volatile RTTank tank;
 
+    private final UntypedWidgetPropertyListener lookChangedListener = this::lookChanged;
+    private final UntypedWidgetPropertyListener valueChangedListener = this::valueChanged;
+
     @Override
     public Pane createJFXNode() throws Exception
     {
@@ -43,19 +47,38 @@ public class TankRepresentation extends RegionBaseRepresentation<Pane, TankWidge
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propForeground().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propBackground().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propFillColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propEmptyColor().addUntypedPropertyListener(this::lookChanged);
+        model_widget.propWidth().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propForeground().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propBackground().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propFillColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propEmptyColor().addUntypedPropertyListener(lookChangedListener);
 
-        model_widget.propLimitsFromPV().addUntypedPropertyListener(this::valueChanged);
-        model_widget.propMinimum().addUntypedPropertyListener(this::valueChanged);
-        model_widget.propMaximum().addUntypedPropertyListener(this::valueChanged);
-        model_widget.runtimePropValue().addUntypedPropertyListener(this::valueChanged);
+        model_widget.propLimitsFromPV().addUntypedPropertyListener(valueChangedListener);
+        model_widget.propMinimum().addUntypedPropertyListener(valueChangedListener);
+        model_widget.propMaximum().addUntypedPropertyListener(valueChangedListener);
+        model_widget.runtimePropValue().addUntypedPropertyListener(valueChangedListener);
         valueChanged(null, null, null);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(lookChangedListener);
+        model_widget.propHeight().removePropertyListener(lookChangedListener);
+        model_widget.propFont().removePropertyListener(lookChangedListener);
+        model_widget.propForeground().removePropertyListener(lookChangedListener);
+        model_widget.propBackground().removePropertyListener(lookChangedListener);
+        model_widget.propFillColor().removePropertyListener(lookChangedListener);
+        model_widget.propEmptyColor().removePropertyListener(lookChangedListener);
+
+        model_widget.propLimitsFromPV().removePropertyListener(valueChangedListener);
+        model_widget.propMinimum().removePropertyListener(valueChangedListener);
+        model_widget.propMaximum().removePropertyListener(valueChangedListener);
+        model_widget.runtimePropValue().removePropertyListener(valueChangedListener);
+
+        super.unregisterListeners();
     }
 
     private void lookChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TextEntryRepresentation.java
@@ -12,7 +12,9 @@ import static org.csstudio.display.builder.representation.ToolkitRepresentation.
 import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.persist.NamedWidgetColors;
 import org.csstudio.display.builder.model.persist.WidgetColorService;
 import org.csstudio.display.builder.model.properties.WidgetColor;
@@ -47,6 +49,11 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
     private volatile String value_text = "<?>";
 
     private static WidgetColor active_color = WidgetColorService.getColor(NamedWidgetColors.ACTIVE_TEXT);
+
+    private final UntypedWidgetPropertyListener contentChangedListener = this::contentChanged;
+    private final UntypedWidgetPropertyListener sizeChangedListener = this::sizeChanged;
+    private final UntypedWidgetPropertyListener styleChangedListener = this::styleChanged;
+    private final WidgetPropertyListener<String> pvnameChangedListener = this::pvnameChanged;
 
     @Override
     public TextInputControl createJFXNode() throws Exception
@@ -213,23 +220,45 @@ public class TextEntryRepresentation extends RegionBaseRepresentation<TextInputC
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::sizeChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::sizeChanged);
+        model_widget.propWidth().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(sizeChangedListener);
 
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propEnabled().addUntypedPropertyListener(this::styleChanged);
-        model_widget.runtimePropPVWritable().addUntypedPropertyListener(this::styleChanged);
+        model_widget.propForegroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propEnabled().addUntypedPropertyListener(styleChangedListener);
+        model_widget.runtimePropPVWritable().addUntypedPropertyListener(styleChangedListener);
 
-        model_widget.propFormat().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propPrecision().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propShowUnits().addUntypedPropertyListener(this::contentChanged);
-        model_widget.runtimePropValue().addUntypedPropertyListener(this::contentChanged);
+        model_widget.propFormat().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propPrecision().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propShowUnits().addUntypedPropertyListener(contentChangedListener);
+        model_widget.runtimePropValue().addUntypedPropertyListener(contentChangedListener);
 
-        model_widget.propPVName().addPropertyListener(this::pvnameChanged);
+        model_widget.propPVName().addPropertyListener(pvnameChangedListener);
 
         contentChanged(null, null, null);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(sizeChangedListener);
+        model_widget.propHeight().removePropertyListener(sizeChangedListener);
+
+        model_widget.propForegroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propBackgroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propFont().removePropertyListener(styleChangedListener);
+        model_widget.propEnabled().removePropertyListener(styleChangedListener);
+        model_widget.runtimePropPVWritable().removePropertyListener(styleChangedListener);
+
+        model_widget.propFormat().removePropertyListener(contentChangedListener);
+        model_widget.propPrecision().removePropertyListener(contentChangedListener);
+        model_widget.propShowUnits().removePropertyListener(contentChangedListener);
+        model_widget.runtimePropValue().removePropertyListener(contentChangedListener);
+
+        model_widget.propPVName().removePropertyListener(pvnameChangedListener);
+
+        super.unregisterListeners();
     }
 
     @Override

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TextUpdateRepresentation.java
@@ -8,7 +8,9 @@
 package org.csstudio.display.builder.representation.javafx.widgets;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.properties.RotationStep;
 import org.csstudio.display.builder.model.properties.WidgetColor;
 import org.csstudio.display.builder.model.util.FormatOptionHandler;
@@ -44,6 +46,10 @@ public class TextUpdateRepresentation extends RegionBaseRepresentation<Control, 
     private volatile String value_text = "<?>";
     private volatile Pos pos;
 
+    private final UntypedWidgetPropertyListener contentChangedListener = this::contentChanged;
+    private final UntypedWidgetPropertyListener styleChangedListener = this::styleChanged;
+    private final WidgetPropertyListener<String> pvnameChangedListener = this::pvnameChanged;
+
     /** Was there ever any transformation applied to the jfx_node?
      *
      *  <p>Used to optimize:
@@ -76,25 +82,48 @@ public class TextUpdateRepresentation extends RegionBaseRepresentation<Control, 
         super.registerListeners();
         pos = JFXUtil.computePos(model_widget.propHorizontalAlignment().getValue(),
                                  model_widget.propVerticalAlignment().getValue());
-        model_widget.propWidth().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propBackgroundColor().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propTransparent().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propFont().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propHorizontalAlignment().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propVerticalAlignment().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propRotationStep().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propWrapWords().addUntypedPropertyListener(this::styleChanged);
-        model_widget.propFormat().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propPrecision().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propShowUnits().addUntypedPropertyListener(this::contentChanged);
-        model_widget.runtimePropValue().addUntypedPropertyListener(this::contentChanged);
+        model_widget.propWidth().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propBackgroundColor().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propTransparent().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propFont().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propHorizontalAlignment().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propVerticalAlignment().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propRotationStep().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propWrapWords().addUntypedPropertyListener(styleChangedListener);
+        model_widget.propFormat().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propPrecision().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propShowUnits().addUntypedPropertyListener(contentChangedListener);
+        model_widget.runtimePropValue().addUntypedPropertyListener(contentChangedListener);
 
-        model_widget.propPVName().addPropertyListener(this::pvnameChanged);
+        model_widget.propPVName().addPropertyListener(pvnameChangedListener);
 
         // Initial update in case runtimePropValue already has value before we registered listener
         contentChanged(null, null, model_widget.runtimePropValue().getValue());
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(styleChangedListener);
+        model_widget.propHeight().removePropertyListener(styleChangedListener);
+        model_widget.propForegroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propBackgroundColor().removePropertyListener(styleChangedListener);
+        model_widget.propTransparent().removePropertyListener(styleChangedListener);
+        model_widget.propFont().removePropertyListener(styleChangedListener);
+        model_widget.propHorizontalAlignment().removePropertyListener(styleChangedListener);
+        model_widget.propVerticalAlignment().removePropertyListener(styleChangedListener);
+        model_widget.propRotationStep().removePropertyListener(styleChangedListener);
+        model_widget.propWrapWords().removePropertyListener(styleChangedListener);
+        model_widget.propFormat().removePropertyListener(contentChangedListener);
+        model_widget.propPrecision().removePropertyListener(contentChangedListener);
+        model_widget.propShowUnits().removePropertyListener(contentChangedListener);
+        model_widget.runtimePropValue().removePropertyListener(contentChangedListener);
+
+        model_widget.propPVName().removePropertyListener(pvnameChangedListener);
+
+        super.unregisterListeners();
     }
 
     @Override

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ThermometerRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ThermometerRepresentation.java
@@ -8,6 +8,7 @@
 package org.csstudio.display.builder.representation.javafx.widgets;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.util.VTypeUtil;
 import org.csstudio.display.builder.model.widgets.ThermometerWidget;
@@ -48,6 +49,9 @@ public class ThermometerRepresentation extends RegionBaseRepresentation<Region, 
     private volatile double max = 0.0;
     private volatile double min = 0.0;
     private volatile double val = 0.0;
+
+    private final UntypedWidgetPropertyListener lookChangedListener = this::lookChanged;
+    private final UntypedWidgetPropertyListener valueChangedListener = this::valueChanged;
 
     @Override
     public Region createJFXNode() throws Exception
@@ -175,19 +179,31 @@ public class ThermometerRepresentation extends RegionBaseRepresentation<Region, 
         }
     }
 
-
     @Override
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propFillColor().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propWidth().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::lookChanged);
-        model_widget.propLimitsFromPV().addUntypedPropertyListener(this::valueChanged);
-        model_widget.propMinimum().addUntypedPropertyListener(this::valueChanged);
-        model_widget.propMaximum().addUntypedPropertyListener(this::valueChanged);
-        model_widget.runtimePropValue().addUntypedPropertyListener(this::valueChanged);
+        model_widget.propFillColor().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propWidth().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(lookChangedListener);
+        model_widget.propLimitsFromPV().addUntypedPropertyListener(valueChangedListener);
+        model_widget.propMinimum().addUntypedPropertyListener(valueChangedListener);
+        model_widget.propMaximum().addUntypedPropertyListener(valueChangedListener);
+        model_widget.runtimePropValue().addUntypedPropertyListener(valueChangedListener);
         valueChanged(null, null, null);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propFillColor().removePropertyListener(lookChangedListener);
+        model_widget.propWidth().removePropertyListener(lookChangedListener);
+        model_widget.propHeight().removePropertyListener(lookChangedListener);
+        model_widget.propLimitsFromPV().removePropertyListener(valueChangedListener);
+        model_widget.propMinimum().removePropertyListener(valueChangedListener);
+        model_widget.propMaximum().removePropertyListener(valueChangedListener);
+        model_widget.runtimePropValue().removePropertyListener(valueChangedListener);
+        super.unregisterListeners();
     }
 
     private void lookChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TooltipSupport.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TooltipSupport.java
@@ -11,6 +11,7 @@ import static org.csstudio.display.builder.model.properties.CommonWidgetProperti
 import static org.csstudio.display.builder.representation.ToolkitRepresentation.logger;
 
 import java.lang.reflect.Field;
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
@@ -120,6 +121,7 @@ public class TooltipSupport
         });
 
         Tooltip.install(node, tooltip);
+        node.getProperties().put("_tooltip", tooltip);
 
         if (! initialized_behavior)
         {
@@ -130,6 +132,19 @@ public class TooltipSupport
             // Java 9 will offer API, https://bugs.openjdk.java.net/browse/JDK-8090477
             hack_behavior(tooltip);
             initialized_behavior = true;
+        }
+    }
+
+
+    /**
+     * Detach tool tip.
+     *
+     * @param node Node that should have the tool tip removed.
+     */
+    public static void detach ( final Node node ) {
+        if ( node != null ) {
+            Optional.ofNullable(node.getProperties().get("_tooltip"))
+                    .ifPresent(t -> Tooltip.uninstall(node, (Tooltip) t));
         }
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TooltipSupport.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/TooltipSupport.java
@@ -141,11 +141,11 @@ public class TooltipSupport
      *
      * @param node Node that should have the tool tip removed.
      */
-    public static void detach ( final Node node ) {
-        if ( node != null ) {
+    public static void detach ( final Node node )
+    {
+        if ( node != null )
             Optional.ofNullable(node.getProperties().get("_tooltip"))
                     .ifPresent(t -> Tooltip.uninstall(node, (Tooltip) t));
-        }
     }
 
     private static void hack_behavior(final Tooltip tooltip)

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/WebBrowserRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/WebBrowserRepresentation.java
@@ -11,7 +11,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import org.csstudio.display.builder.model.DirtyFlag;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
+import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.util.ModelResourceUtil;
 import org.csstudio.display.builder.model.widgets.WebBrowserWidget;
 import org.csstudio.display.builder.util.ResourceUtil;
@@ -50,6 +52,9 @@ public class WebBrowserRepresentation extends RegionBaseRepresentation<Region, W
     private volatile double height;
 
     private static final String[] downloads = new String[] { "zip", "csv", "cif", "tgz" };
+
+    private final UntypedWidgetPropertyListener sizeChangedListener = this::sizeChanged;
+    private final WidgetPropertyListener<String> urlChangedListener = this::urlChanged;
 
     class Browser extends Region
     {
@@ -314,12 +319,23 @@ public class WebBrowserRepresentation extends RegionBaseRepresentation<Region, W
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::sizeChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::sizeChanged);
+        model_widget.propWidth().addUntypedPropertyListener(sizeChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(sizeChangedListener);
         if (!toolkit.isEditMode())
-            model_widget.propWidgetURL().addPropertyListener(this::urlChanged);
+            model_widget.propWidgetURL().addPropertyListener(urlChangedListener);
         //the showToolbar property cannot be changed at runtime
    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(sizeChangedListener);
+        model_widget.propHeight().removePropertyListener(sizeChangedListener);
+        if (!toolkit.isEditMode())
+            model_widget.propWidgetURL().removePropertyListener(urlChangedListener);
+        //the showToolbar property cannot be changed at runtime
+        super.unregisterListeners();
+    }
 
     private void sizeChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)
     {

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/plots/ImageRepresentation.java
@@ -9,6 +9,7 @@ package org.csstudio.display.builder.representation.javafx.widgets.plots;
 
 import static org.csstudio.display.builder.representation.ToolkitRepresentation.logger;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -16,6 +17,7 @@ import java.util.logging.Level;
 
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.DisplayModel;
+import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
 import org.csstudio.display.builder.model.WidgetPropertyListener;
 import org.csstudio.display.builder.model.macros.MacroHandler;
@@ -144,6 +146,14 @@ public class ImageRepresentation extends RegionBaseRepresentation<Pane, ImageWid
         }
     };
 
+    private final UntypedWidgetPropertyListener coloringChangedListener = this::coloringChanged;
+    private final UntypedWidgetPropertyListener configChangedListener = this::configChanged;
+    private final UntypedWidgetPropertyListener contentChangedListener = this::contentChanged;
+    private final UntypedWidgetPropertyListener positionChangedListener = this::positionChanged;
+    private final UntypedWidgetPropertyListener rangeChangedListener = this::rangeChanged;
+    private final WidgetPropertyListener<Double[]> crosshairChangedListener = this::crosshairChanged;
+    private final WidgetPropertyListener<Instant> runtimeConfigChangedListener = (p, o, n) -> image_plot.showConfigurationDialog();
+
     @Override
     public Pane createJFXNode() throws Exception
     {
@@ -243,33 +253,33 @@ public class ImageRepresentation extends RegionBaseRepresentation<Pane, ImageWid
     protected void registerListeners()
     {
         super.registerListeners();
-        model_widget.propWidth().addUntypedPropertyListener(this::positionChanged);
-        model_widget.propHeight().addUntypedPropertyListener(this::positionChanged);
+        model_widget.propWidth().addUntypedPropertyListener(positionChangedListener);
+        model_widget.propHeight().addUntypedPropertyListener(positionChangedListener);
 
-        model_widget.propToolbar().addUntypedPropertyListener(this::configChanged);
-        model_widget.propBackground().addUntypedPropertyListener(this::configChanged);
-        model_widget.propForegroundColor().addUntypedPropertyListener(this::configChanged);
-        model_widget.propColorbar().visible().addUntypedPropertyListener(this::configChanged);
-        model_widget.propColorbar().barSize().addUntypedPropertyListener(this::configChanged);
-        model_widget.propColorbar().scaleFont().addUntypedPropertyListener(this::configChanged);
-        model_widget.propCursorCrosshair().addUntypedPropertyListener(this::configChanged);
+        model_widget.propToolbar().addUntypedPropertyListener(configChangedListener);
+        model_widget.propBackground().addUntypedPropertyListener(configChangedListener);
+        model_widget.propForegroundColor().addUntypedPropertyListener(configChangedListener);
+        model_widget.propColorbar().visible().addUntypedPropertyListener(configChangedListener);
+        model_widget.propColorbar().barSize().addUntypedPropertyListener(configChangedListener);
+        model_widget.propColorbar().scaleFont().addUntypedPropertyListener(configChangedListener);
+        model_widget.propCursorCrosshair().addUntypedPropertyListener(configChangedListener);
         addAxisListener(model_widget.propXAxis());
         addAxisListener(model_widget.propYAxis());
 
-        model_widget.propDataInterpolation().addUntypedPropertyListener(this::coloringChanged);
-        model_widget.propDataColormap().addUntypedPropertyListener(this::coloringChanged);
-        model_widget.propDataAutoscale().addUntypedPropertyListener(this::rangeChanged);
-        model_widget.propDataLogscale().addUntypedPropertyListener(this::rangeChanged);
-        model_widget.propDataMinimum().addUntypedPropertyListener(this::rangeChanged);
-        model_widget.propDataMaximum().addUntypedPropertyListener(this::rangeChanged);
+        model_widget.propDataInterpolation().addUntypedPropertyListener(coloringChangedListener);
+        model_widget.propDataColormap().addUntypedPropertyListener(coloringChangedListener);
+        model_widget.propDataAutoscale().addUntypedPropertyListener(rangeChangedListener);
+        model_widget.propDataLogscale().addUntypedPropertyListener(rangeChangedListener);
+        model_widget.propDataMinimum().addUntypedPropertyListener(rangeChangedListener);
+        model_widget.propDataMaximum().addUntypedPropertyListener(rangeChangedListener);
 
-        model_widget.propDataWidth().addUntypedPropertyListener(this::contentChanged);
-        model_widget.propDataHeight().addUntypedPropertyListener(this::contentChanged);
-        model_widget.runtimePropValue().addUntypedPropertyListener(this::contentChanged);
+        model_widget.propDataWidth().addUntypedPropertyListener(contentChangedListener);
+        model_widget.propDataHeight().addUntypedPropertyListener(contentChangedListener);
+        model_widget.runtimePropValue().addUntypedPropertyListener(contentChangedListener);
 
-        model_widget.runtimePropCrosshair().addPropertyListener(this::crosshairChanged);
+        model_widget.runtimePropCrosshair().addPropertyListener(crosshairChangedListener);
 
-        model_widget.runtimePropConfigure().addPropertyListener((p, o, n) -> image_plot.showConfigurationDialog() );
+        model_widget.runtimePropConfigure().addPropertyListener(runtimeConfigChangedListener);
 
         image_plot.setListener(plot_listener);
 
@@ -282,12 +292,56 @@ public class ImageRepresentation extends RegionBaseRepresentation<Pane, ImageWid
 
     private void addAxisListener(final AxisWidgetProperty axis)
     {
-        axis.visible().addUntypedPropertyListener(this::configChanged);
-        axis.title().addUntypedPropertyListener(this::configChanged);
-        axis.minimum().addUntypedPropertyListener(this::configChanged);
-        axis.maximum().addUntypedPropertyListener(this::configChanged);
-        axis.titleFont().addUntypedPropertyListener(this::configChanged);
-        axis.scaleFont().addUntypedPropertyListener(this::configChanged);
+        axis.visible().addUntypedPropertyListener(configChangedListener);
+        axis.title().addUntypedPropertyListener(configChangedListener);
+        axis.minimum().addUntypedPropertyListener(configChangedListener);
+        axis.maximum().addUntypedPropertyListener(configChangedListener);
+        axis.titleFont().addUntypedPropertyListener(configChangedListener);
+        axis.scaleFont().addUntypedPropertyListener(configChangedListener);
+    }
+
+    @Override
+    protected void unregisterListeners()
+    {
+        model_widget.propWidth().removePropertyListener(positionChangedListener);
+        model_widget.propHeight().removePropertyListener(positionChangedListener);
+
+        model_widget.propToolbar().removePropertyListener(configChangedListener);
+        model_widget.propBackground().removePropertyListener(configChangedListener);
+        model_widget.propForegroundColor().removePropertyListener(configChangedListener);
+        model_widget.propColorbar().visible().removePropertyListener(configChangedListener);
+        model_widget.propColorbar().barSize().removePropertyListener(configChangedListener);
+        model_widget.propColorbar().scaleFont().removePropertyListener(configChangedListener);
+        model_widget.propCursorCrosshair().removePropertyListener(configChangedListener);
+        removeAxisListener(model_widget.propXAxis());
+        removeAxisListener(model_widget.propYAxis());
+
+        model_widget.propDataInterpolation().removePropertyListener(coloringChangedListener);
+        model_widget.propDataColormap().removePropertyListener(coloringChangedListener);
+        model_widget.propDataAutoscale().removePropertyListener(rangeChangedListener);
+        model_widget.propDataLogscale().removePropertyListener(rangeChangedListener);
+        model_widget.propDataMinimum().removePropertyListener(rangeChangedListener);
+        model_widget.propDataMaximum().removePropertyListener(rangeChangedListener);
+
+        model_widget.propDataWidth().removePropertyListener(contentChangedListener);
+        model_widget.propDataHeight().removePropertyListener(contentChangedListener);
+        model_widget.runtimePropValue().removePropertyListener(contentChangedListener);
+
+        model_widget.runtimePropCrosshair().removePropertyListener(crosshairChangedListener);
+
+        model_widget.runtimePropConfigure().removePropertyListener(runtimeConfigChangedListener);
+
+        super.unregisterListeners();
+    }
+
+    private void removeAxisListener(final AxisWidgetProperty axis)
+    {
+        axis.visible().removePropertyListener(configChangedListener);
+        axis.title().removePropertyListener(configChangedListener);
+        axis.minimum().removePropertyListener(configChangedListener);
+        axis.maximum().removePropertyListener(configChangedListener);
+        axis.titleFont().removePropertyListener(configChangedListener);
+        axis.scaleFont().removePropertyListener(configChangedListener);
     }
 
     private void positionChanged(final WidgetProperty<?> property, final Object old_value, final Object new_value)


### PR DESCRIPTION
The problem is caused by not unregistering listeners when widgets are disposed.

Specifically it happens in SelectedWidgetUITracker:429-430. The widgets dragged into a Group, for example, are removed from their original parent (e.g. Display) and added to the new one (e.g. Group). When removed they are disposed but the listeners previously registered are not unregistered, so those listeners still keep alive the previous representation that now has its `toolkit` set to `null`. When added to the new parent they are initialised, adding new listeners. So, when the widget is asked for a redraw the new and the old location listeners are invoked, and the old one will throws the NPE.

What I've done is to add the `unregisterListeners` to the JFXBaseRepresentation and to the derived class Ellipse (just for test).

@kasemir 
Please don't merge this PR yet: I've created it to explain the problem to you. I'm working on adding `unregisterListeners` to all the representation classes. I'll tell you when finished.