### PR TITLE
Removing the 1px border around EmbeddedDisplay's content .

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
@@ -85,28 +85,6 @@
     -fx-text-overrun: clip;
 }
 
-/** Embedded display uses a ScrollPane.
- *  That pane has a 'background' which only appears as a small rim.
- *  The bulk is handled by a 'viewport' inside the skin,
- *  which is hard to access since lookup(".viewport") only works
- *  after the widgets have been rendered.
- *
- *  -> Make the embedded display scroll pane
- *     transparent and handle all coloring
- *     via the 'inner' pane in the code.
- */
-.embedded_display
-{
-    /* Hide small border around scroll pane, see
-     * http://stackoverflow.com/questions/17540137/javafx-scrollpane-border-and-background/17540428#17540428
-     */
-    -fx-background-color: transparent;
-}
-.embedded_display > .viewport
-{
-    -fx-background-color: transparent;
-}
-
 /* NavigationTabs:
  * tabregion with buttons; horizontal or vertical(default).
  * body contains the embedded widgets.

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
@@ -102,7 +102,7 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
         inner.getTransforms().add(zoom = new Scale());
 
         scroll = new ScrollPane(inner);
-        scroll.getStyleClass().add("embedded_display");
+        scroll.getStyleClass().add("edge-to-edge");
         // Panning tends to 'jerk' the content when clicked
         // scroll.setPannable(true);
         return scroll;
@@ -149,8 +149,8 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
             final int content_height = content_model.propHeight().getValue();
             if (resize == Resize.ResizeContent)
             {   // Adjust sizes by +-1 so that content is completely visible
-                final double zoom_x = content_width  > 0 ? (double)(widget_width-1)  / (content_width+1) : 1.0;
-                final double zoom_y = content_height > 0 ? (double)(widget_height-1) / (content_height+1) : 1.0;
+                final double zoom_x = content_width  > 0 ? (double) widget_width  / content_width : 1.0;
+                final double zoom_y = content_height > 0 ? (double) widget_height / content_height : 1.0;
                 zoom_factor = Math.min(zoom_x, zoom_y);
             }
             else if (resize == Resize.SizeToContent)
@@ -159,9 +159,9 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
                 resizing = true;
                 // Adjust sizes by 2 so that content is completely visible
                 if (content_width > 0)
-                    model_widget.propWidth().setValue(content_width+2);
+                    model_widget.propWidth().setValue(content_width);
                 if (content_height > 0)
-                    model_widget.propHeight().setValue(content_height+2);
+                    model_widget.propHeight().setValue(content_height);
                 resizing = false;
             }
         }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
@@ -102,6 +102,7 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
         inner.getTransforms().add(zoom = new Scale());
 
         scroll = new ScrollPane(inner);
+        //  Removing 1px border around the ScrollPane's content. See https://stackoverflow.com/a/29376445
         scroll.getStyleClass().add("edge-to-edge");
         // Panning tends to 'jerk' the content when clicked
         // scroll.setPannable(true);


### PR DESCRIPTION
Using the Modena CSS `edge-to-edge` style for ScrollPane instead of `embedded_display`, and removed the extra pixels in width and height when resized.

See https://stackoverflow.com/a/29376445