### PR TITLE
Wrong transparent background in EmbeddedDisplay.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/opibuilder.css
@@ -85,6 +85,28 @@
     -fx-text-overrun: clip;
 }
 
+/** Embedded display uses a ScrollPane.
+ *  That pane has a 'background' which only appears as a small rim.
+ *  The bulk is handled by a 'viewport' inside the skin,
+ *  which is hard to access since lookup(".viewport") only works
+ *  after the widgets have been rendered.
+ *
+ *  -> Make the embedded display scroll pane
+ *     transparent and handle all coloring
+ *     via the 'inner' pane in the code.
+ */
+.embedded_display
+{
+    /* Hide small border around scroll pane, see
+     * http://stackoverflow.com/questions/17540137/javafx-scrollpane-border-and-background/17540428#17540428
+     */
+    -fx-background-color: transparent;
+}
+.embedded_display > .viewport
+{
+    -fx-background-color: transparent;
+}
+
 /* NavigationTabs:
  * tabregion with buttons; horizontal or vertical(default).
  * body contains the embedded widgets.

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
@@ -355,7 +355,6 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
         }
         if (dirty_background.checkAndClear())
         {
-            scroll.setBackground(inner_background);
             inner.setBackground(inner_background);
             inner.setBorder(inner_border);
         }

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
@@ -55,7 +55,7 @@ import javafx.scene.transform.Scale;
 public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<ScrollPane, EmbeddedDisplayWidget>
 {
     private static final Background TRANSPARENT_BACKGROUND = new Background(new BackgroundFill(Color.TRANSPARENT, CornerRadii.EMPTY, Insets.EMPTY));
-    private static final Border EDIT_BORDER = new Border(new BorderStroke(Color.LIGHTGRAY, BorderStrokeStyle.SOLID, CornerRadii.EMPTY, BorderWidths.DEFAULT));
+    private static final Border EDIT_BORDER = new Border(new BorderStroke(new Color(0.45, 0.44, 0.43, 0.7), BorderStrokeStyle.DOTTED, CornerRadii.EMPTY, BorderWidths.DEFAULT));
 
     private final DirtyFlag dirty_sizes = new DirtyFlag();
     private final DirtyFlag dirty_background = new DirtyFlag();
@@ -107,7 +107,7 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
 
         scroll = new ScrollPane(inner);
         //  Removing 1px border around the ScrollPane's content. See https://stackoverflow.com/a/29376445
-        scroll.getStyleClass().add("edge-to-edge");
+        scroll.getStyleClass().addAll("embedded_display", "edge-to-edge");
         // Panning tends to 'jerk' the content when clicked
         // scroll.setPannable(true);
         return scroll;
@@ -156,8 +156,8 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
         final int widget_width = model_widget.propWidth().getValue();
         final int widget_height = model_widget.propHeight().getValue();
         // "-2" to prevent triggering scrollbars
-        inner.setMinWidth(widget_width-2);
-        inner.setMinHeight(widget_height-2);
+        inner.setMinWidth(widget_width);
+        inner.setMinHeight(widget_height);
 
         final Resize resize = model_widget.propResize().getValue();
         final DisplayModel content_model = active_content_model.get();
@@ -355,6 +355,7 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
         }
         if (dirty_background.checkAndClear())
         {
+            scroll.setBackground(inner_background);
             inner.setBackground(inner_background);
             inner.setBorder(inner_border);
         }


### PR DESCRIPTION
The previous style class "embedded-display " was substituted with "edge-to-edge". In this way the transparency is lost.

Both style classes must be added to the ScrollView: one for the transparency, the other for the removal of 1px border.