### PR TITLE
Default to POINTER in DataBrowser

### DIFF
--- a/org.csstudio.javafx.rtplot/src/org/csstudio/javafx/rtplot/internal/ToolbarHandler.java
+++ b/org.csstudio.javafx.rtplot/src/org/csstudio/javafx/rtplot/internal/ToolbarHandler.java
@@ -166,7 +166,7 @@ public class ToolbarHandler<XTYPE extends Comparable<XTYPE>>
         toolbar.getItems().add(new Separator());
         addUndo(active);
 
-        // Initially, panning is selected
+        // Initially, pointer is selected
         selectMouseMode(pointer);
     }
 

--- a/org.csstudio.javafx.rtplot/src/org/csstudio/javafx/rtplot/internal/ToolbarHandler.java
+++ b/org.csstudio.javafx.rtplot/src/org/csstudio/javafx/rtplot/internal/ToolbarHandler.java
@@ -167,7 +167,7 @@ public class ToolbarHandler<XTYPE extends Comparable<XTYPE>>
         addUndo(active);
 
         // Initially, panning is selected
-        selectMouseMode(pan);
+        selectMouseMode(pointer);
     }
 
     private void addOptions(final boolean active)


### PR DESCRIPTION
The PAN mode changes the min and max of vertical axes, possibly disrupting a carefully set ones. For this reason I was asked to have the POINTER mode set as default.

I did it in a straight way. I don't know if you @kasemir prefer to have a preference instead.