### PR TITLE
LED colour alway magenta in editor mode

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -168,9 +168,9 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
 
     private void contentChanged(final WidgetProperty<VType> property, final VType old_value, final VType new_value)
     {
-        final boolean editMode = toolkit.isEditMode();
+        final boolean runtimeMode = ! toolkit.isEditMode();
         final VType value = model_widget.runtimePropValue().getValue();
-        if (value == null && ! editMode)
+        if (value == null && runtimeMode)
         {
             value_color = alarm_colors[AlarmSeverity.UNDEFINED.ordinal()];
             value_label = "";
@@ -183,7 +183,7 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
                 value_index = 0;
             if (value_index >= save_colors.length)
                 value_index = save_colors.length-1;
-            value_color = editMode ? editColor(save_colors) : save_colors[value_index];
+            value_color = runtimeMode ? save_colors[value_index] : editColor();
             value_label = computeLabel(value_index);
         }
 
@@ -191,8 +191,9 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
         toolkit.scheduleUpdate(this);
     }
 
-    private Paint editColor ( final Color[] save_colors ) {
+    private Paint editColor ( ) {
 
+        final Color[] save_colors = colors;
         List<Stop> stops = new ArrayList<>(2 * save_colors.length);
         double offset = 1.0 / save_colors.length;
 
@@ -201,7 +202,7 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
             stops.add(new Stop(( i + 1 ) * offset, save_colors[i]));
         }
 
-        return new LinearGradient(0, 0, 1, 0, true, CycleMethod.NO_CYCLE, stops);
+        return new LinearGradient(0, 0, 1, 1, true, CycleMethod.NO_CYCLE, stops);
 
     }
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BaseLEDRepresentation.java
@@ -7,6 +7,9 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.widgets;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.csstudio.display.builder.model.DirtyFlag;
 import org.csstudio.display.builder.model.UntypedWidgetPropertyListener;
 import org.csstudio.display.builder.model.WidgetProperty;
@@ -20,6 +23,10 @@ import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.CycleMethod;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Paint;
+import javafx.scene.paint.Stop;
 import javafx.scene.shape.Ellipse;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.shape.Shape;
@@ -40,7 +47,7 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
 
     protected volatile Color[] colors = new Color[0];
 
-    protected volatile Color value_color;
+    protected volatile Paint value_color;
     protected volatile String value_label;
 
     /** Actual LED Ellipse or Rectangle inside {@link Pane} to allow for border */
@@ -161,8 +168,9 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
 
     private void contentChanged(final WidgetProperty<VType> property, final VType old_value, final VType new_value)
     {
+        final boolean editMode = toolkit.isEditMode();
         final VType value = model_widget.runtimePropValue().getValue();
-        if (value == null)
+        if (value == null && ! editMode)
         {
             value_color = alarm_colors[AlarmSeverity.UNDEFINED.ordinal()];
             value_label = "";
@@ -175,12 +183,26 @@ abstract class BaseLEDRepresentation<LED extends BaseLEDWidget> extends RegionBa
                 value_index = 0;
             if (value_index >= save_colors.length)
                 value_index = save_colors.length-1;
-            value_color = save_colors[value_index];
+            value_color = editMode ? editColor(save_colors) : save_colors[value_index];
             value_label = computeLabel(value_index);
         }
 
         dirty_content.mark();
         toolkit.scheduleUpdate(this);
+    }
+
+    private Paint editColor ( final Color[] save_colors ) {
+
+        List<Stop> stops = new ArrayList<>(2 * save_colors.length);
+        double offset = 1.0 / save_colors.length;
+
+        for ( int i = 0; i < save_colors.length; i++ ) {
+            stops.add(new Stop(i * offset, save_colors[i]));
+            stops.add(new Stop(( i + 1 ) * offset, save_colors[i]));
+        }
+
+        return new LinearGradient(0, 0, 1, 0, true, CycleMethod.NO_CYCLE, stops);
+
     }
 
     @Override

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
@@ -9,6 +9,7 @@ package org.csstudio.display.builder.representation.javafx.widgets;
 
 import static org.csstudio.display.builder.representation.ToolkitRepresentation.logger;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -31,6 +32,10 @@ import javafx.scene.control.ButtonBase;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.CycleMethod;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Paint;
+import javafx.scene.paint.Stop;
 import javafx.scene.shape.Ellipse;
 
 /** Creates JavaFX item for model widget
@@ -270,6 +275,19 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
         toolkit.scheduleUpdate(this);
     }
 
+    private Paint editColor ( ) {
+
+        final Color[] save_colors = state_colors;
+
+        return new LinearGradient(0, 0, 1, 1, true, CycleMethod.NO_CYCLE, Arrays.asList(
+            new Stop(0.0, save_colors[0]),
+            new Stop(0.5, save_colors[0]),
+            new Stop(0.5, save_colors[1]),
+            new Stop(1.0, save_colors[1])
+        ));
+
+    }
+
     @Override
     public void updateChanges()
     {
@@ -316,7 +334,7 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
                 jfx_node.setGraphic(led);
                 // Put highlight in top-left corner, about 0.2 wide,
                 // relative to actual size of LED
-                led.setFill(value_color);
+                led.setFill(toolkit.isEditMode() ? editColor() : value_color);
             }
             else
                 jfx_node.setGraphic(image);

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/ByteMonitorRepresentation.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.csstudio.display.builder.representation.javafx.widgets;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.csstudio.display.builder.model.DirtyFlag;
@@ -24,6 +25,10 @@ import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.CycleMethod;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Paint;
+import javafx.scene.paint.Stop;
 import javafx.scene.shape.Ellipse;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.shape.Shape;
@@ -185,7 +190,7 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
             led.getStyleClass().add("led");
             led.setManaged(false);
             if (save_colorVals != null && i < save_colorVals.length)
-                led.setFill(save_colorVals[i]);
+                led.setFill(toolkit.isEditMode() ? editColor() : save_colorVals[i]);
 
             leds[i] = led;
             labels[i] = label;
@@ -364,6 +369,19 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
         toolkit.scheduleUpdate(this);
     }
 
+    private Paint editColor ( ) {
+
+        final Color[] save_colors = colors;
+
+        return new LinearGradient(0, 0, 1, 1, true, CycleMethod.NO_CYCLE, Arrays.asList(
+            new Stop(0.0, save_colors[0]),
+            new Stop(0.5, save_colors[0]),
+            new Stop(0.5, save_colors[1]),
+            new Stop(1.0, save_colors[1])
+        ));
+
+    }
+
     @Override
     public void updateChanges()
     {
@@ -384,7 +402,7 @@ public class ByteMonitorRepresentation extends RegionBaseRepresentation<Pane, By
 
             final int N = Math.min(save_leds.length, save_values.length);
             for (int i = 0; i < N; i++)
-                leds[i].setFill(save_values[i]);
+                leds[i].setFill(toolkit.isEditMode() ? editColor() : save_values[i]);
         }
     }
 }


### PR DESCRIPTION
I was reported that in the last version of Display Builder LED and MultiLED widgets always shows the Magenta (invalid/unconnected) colour in edit mode, instead of the OFF/State-0 one. In runtime mode, instead, everything was fine.

<img width="614" alt="screenshot 2019-01-29 at 10 15 49" src="https://user-images.githubusercontent.com/10833922/51897761-c271d600-23af-11e9-80c2-8c1d9ee096c1.png">

The fix was easy (`BaseLEDRepresentation:173`). I've improved (I think at least) how LEDs (LED, MultiLed, BoolButton and ByteMonitor) are displayed in edit mode, showing all the colours:

<img width="614" alt="screenshot 2019-01-29 at 10 15 06" src="https://user-images.githubusercontent.com/10833922/51897947-2399a980-23b0-11e9-8ee9-e35d6ac23921.png">

Here and example of what a synoptic view looks like in edit mode after the change:

<img width="1232" alt="screenshot 2019-01-29 at 10 18 01" src="https://user-images.githubusercontent.com/10833922/51898013-49bf4980-23b0-11e9-9165-c03e4d3e751e.png">
