### PR TITLE
Context menu triggering event forwarded to parent for Spinner widget when right-clicked in the text area.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
@@ -153,6 +153,8 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<Stri
             if ( node.getStyleClass().contains("increment-arrow-button")
               || node.getStyleClass().contains("decrement-arrow-button") ) {
                e.consume();
+            } else {
+                spinner.getParent().fireEvent(e);
             }
 
         });

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
@@ -26,6 +26,7 @@ import org.diirt.vtype.ValueUtil;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleDoubleProperty;
+import javafx.event.Event;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.Spinner;
@@ -150,14 +151,12 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<Stri
             // the button (probably because SWT remember the JFX cursor's position
             // when the menu was triggered).
             // This implementation will limit the context menu only inside the text area.
-            if ( node.getStyleClass().contains("increment-arrow-button")
-              || node.getStyleClass().contains("decrement-arrow-button") ) {
-               e.consume();
-            } else {
-                // Allow SVW context-menu be opened on top of the JavaFX one
-                // when right-clicking on the text area.
-                spinner.getParent().fireEvent(e);
+            if ( !node.getStyleClass().contains("increment-arrow-button")
+              && !node.getStyleClass().contains("decrement-arrow-button") ) {
+                spinner.getParent().fireEvent((Event) e.clone());
             }
+
+            e.consume();
 
         });
 

--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/SpinnerRepresentation.java
@@ -154,6 +154,8 @@ public class SpinnerRepresentation extends RegionBaseRepresentation<Spinner<Stri
               || node.getStyleClass().contains("decrement-arrow-button") ) {
                e.consume();
             } else {
+                // Allow SVW context-menu be opened on top of the JavaFX one
+                // when right-clicking on the text area.
                 spinner.getParent().fireEvent(e);
             }
 


### PR DESCRIPTION
In this way both the JavaFX (below) and the SWT context menus are displayed when right-clicking on the spinner's text area.
Pressing ESC will close the SWT menu. Pressing ESC again will close the JavaFX one.
I's a compromise I know, but that way we solve the problem, at least until we'll move to Phoebus.