### PR TITLE
Added "request_type" preference to set the default request type in Data Browser.

### DIFF
--- a/databrowser3/databrowser-plugins/org.csstudio.trends.databrowser3/preferences.ini
+++ b/databrowser3/databrowser-plugins/org.csstudio.trends.databrowser3/preferences.ini
@@ -101,3 +101,7 @@ scroll_step = 5
 # Display the trace names on the Value Axis
 # the default value is "true". "false" to not show the trace names on the Axis
 use_trace_names = true
+
+# Default request type for newly created trace/PVItem
+# Valid values are: RAW and OPTIMIZED
+request_type=OPTIMIZED

--- a/databrowser3/databrowser-plugins/org.csstudio.trends.databrowser3/src/org/csstudio/trends/databrowser3/model/PVItem.java
+++ b/databrowser3/databrowser-plugins/org.csstudio.trends.databrowser3/src/org/csstudio/trends/databrowser3/model/PVItem.java
@@ -111,7 +111,7 @@ public class PVItem extends ModelItem
     private ScheduledFuture<?> scanner = null;
 
     /** Archive data request type */
-    private RequestType request_type = RequestType.OPTIMIZED;
+    private RequestType request_type = Preferences.getRequestType();
 
     /** Indicating if the history data is automatically refreshed, whenever
      * the live buffer is too small to show all the data */

--- a/databrowser3/databrowser-plugins/org.csstudio.trends.databrowser3/src/org/csstudio/trends/databrowser3/preferences/Preferences.java
+++ b/databrowser3/databrowser-plugins/org.csstudio.trends.databrowser3/src/org/csstudio/trends/databrowser3/preferences/Preferences.java
@@ -17,6 +17,7 @@ import org.csstudio.javafx.rtplot.TraceType;
 import org.csstudio.trends.databrowser3.Activator;
 import org.csstudio.trends.databrowser3.model.ArchiveDataSource;
 import org.csstudio.trends.databrowser3.model.ArchiveRescale;
+import org.csstudio.trends.databrowser3.model.RequestType;
 import org.csstudio.utility.singlesource.SingleSourcePlugin;
 import org.diirt.util.time.TimeDuration;
 import org.eclipse.core.runtime.IPath;
@@ -66,7 +67,8 @@ public class Preferences
             SECURE_DATA_BROWSER = "secure_data_browser",
             AUTOMATIC_HISTORY_REFRESH = "automatic_history_refresh",
             SCROLL_STEP = "scroll_step",
-            USE_TRACE_NAMES = "use_trace_names";
+            USE_TRACE_NAMES = "use_trace_names",
+            REQUEST_TYPE="request_type";
 
     public static boolean isAutomaticHistoryRefresh()
     {
@@ -150,6 +152,24 @@ public class Preferences
             }
         }
         return TraceType.AREA;
+    }
+
+    public static RequestType getRequestType()
+    {
+        final IPreferencesService prefs = Platform.getPreferencesService();
+        if (prefs != null)
+        {
+            final String type_name = prefs.getString(Activator.PLUGIN_ID, REQUEST_TYPE, RequestType.OPTIMIZED.name(), null);
+            try
+            {
+                return RequestType.valueOf(type_name);
+            }
+            catch (Exception ex)
+            {
+                Activator.getLogger().log(Level.WARNING, "Undefined request type option '" + type_name + "'", ex);
+            }
+        }
+        return RequestType.OPTIMIZED;
     }
 
     public static long getArchiveFetchDelay()


### PR DESCRIPTION
I was requested to set the request type default value of a newly added trace to RAW instead of OPTIMIZED. I've added the preference into the ini file and the logic for it. I've set OPTIMIZED as default value in the ini file as it was originally in the code.