### PR TITLE
Updated alignment behaviour

### DIFF
--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/actions/ActionDescription.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/actions/ActionDescription.java
@@ -191,11 +191,11 @@ public abstract class ActionDescription
             final UndoableActionManager undo = editor.getUndoableActionManager();
             if (widgets.size() < 2)
                 return;
-            final int dest = widgets.stream()
-                                    .mapToInt(w -> w.propX().getValue())
-                                    .min()
-                                    .orElseThrow(NoSuchElementException::new);
-            widgets.stream().forEach(w -> undo.execute(new SetWidgetPropertyAction<Integer>(w.propX(), dest)));
+            final int min = widgets.stream()
+                                   .mapToInt(w -> w.propX().getValue())
+                                   .min()
+                                   .orElseThrow(NoSuchElementException::new);
+            widgets.stream().forEach(w -> undo.execute(new SetWidgetPropertyAction<Integer>(w.propX(), min)));
         }
     };
 
@@ -210,10 +210,18 @@ public abstract class ActionDescription
             final UndoableActionManager undo = editor.getUndoableActionManager();
             if (widgets.size() < 2)
                 return;
-            final int dest = widgets.get(0).propX().getValue() + widgets.get(0).propWidth().getValue() / 2;
-            for (int i=1; i<widgets.size(); ++i)
+            final int min = widgets.stream()
+                                   .mapToInt(w -> w.propX().getValue())
+                                   .min()
+                                   .orElseThrow(NoSuchElementException::new);
+            final int max = widgets.stream()
+                                   .mapToInt(w -> w.propX().getValue() + w.propWidth().getValue())
+                                   .max()
+                                   .orElseThrow(NoSuchElementException::new);
+            final int center = ( min + max ) / 2;
+            for (int i=0; i<widgets.size(); ++i)
                 undo.execute(new SetWidgetPropertyAction<Integer>(widgets.get(i).propX(),
-                                                                  dest - widgets.get(i).propWidth().getValue()/2));
+                                                                  center - widgets.get(i).propWidth().getValue()/2));
         }
     };
 
@@ -228,11 +236,11 @@ public abstract class ActionDescription
             final UndoableActionManager undo = editor.getUndoableActionManager();
             if (widgets.size() < 2)
                 return;
-            final int dest = widgets.stream()
-                                    .mapToInt(w -> w.propX().getValue() + w.propWidth().getValue())
-                                    .max()
-                                    .orElseThrow(NoSuchElementException::new);
-            widgets.stream().forEach(w -> undo.execute(new SetWidgetPropertyAction<Integer>(w.propX(), dest - w.propWidth().getValue())));
+            final int max = widgets.stream()
+                                   .mapToInt(w -> w.propX().getValue() + w.propWidth().getValue())
+                                   .max()
+                                   .orElseThrow(NoSuchElementException::new);
+            widgets.stream().forEach(w -> undo.execute(new SetWidgetPropertyAction<Integer>(w.propX(), max - w.propWidth().getValue())));
         }
     };
 
@@ -247,9 +255,12 @@ public abstract class ActionDescription
             final UndoableActionManager undo = editor.getUndoableActionManager();
             if (widgets.size() < 2)
                 return;
-            final int dest = widgets.get(0).propY().getValue();
-            for (int i=1; i<widgets.size(); ++i)
-                undo.execute(new SetWidgetPropertyAction<Integer>(widgets.get(i).propY(), dest));
+            final int min = widgets.stream()
+                                   .mapToInt(w -> w.propY().getValue())
+                                   .min()
+                                   .orElseThrow(NoSuchElementException::new);
+            for (int i=0; i<widgets.size(); ++i)
+                undo.execute(new SetWidgetPropertyAction<Integer>(widgets.get(i).propY(), min));
         }
     };
 
@@ -264,10 +275,18 @@ public abstract class ActionDescription
             final UndoableActionManager undo = editor.getUndoableActionManager();
             if (widgets.size() < 2)
                 return;
-            final int dest = widgets.get(0).propY().getValue() + widgets.get(0).propHeight().getValue()/2;
-            for (int i=1; i<widgets.size(); ++i)
+            final int min = widgets.stream()
+                                   .mapToInt(w -> w.propY().getValue())
+                                   .min()
+                                   .orElseThrow(NoSuchElementException::new);
+            final int max = widgets.stream()
+                                   .mapToInt(w -> w.propY().getValue() + w.propHeight().getValue())
+                                   .max()
+                                   .orElseThrow(NoSuchElementException::new);
+            final int middle = ( min + max ) / 2;
+            for (int i=0; i<widgets.size(); ++i)
                 undo.execute(new SetWidgetPropertyAction<Integer>(widgets.get(i).propY(),
-                                                                  dest - widgets.get(i).propHeight().getValue()/2));
+                                                                  middle - widgets.get(i).propHeight().getValue()/2));
         }
     };
 
@@ -282,10 +301,13 @@ public abstract class ActionDescription
             final UndoableActionManager undo = editor.getUndoableActionManager();
             if (widgets.size() < 2)
                 return;
-            final int dest = widgets.get(0).propY().getValue() + widgets.get(0).propHeight().getValue();
-            for (int i=1; i<widgets.size(); ++i)
+            final int max = widgets.stream()
+                                   .mapToInt(w -> w.propY().getValue() + w.propHeight().getValue())
+                                   .max()
+                                   .orElseThrow(NoSuchElementException::new);
+            for (int i=0; i<widgets.size(); ++i)
                 undo.execute(new SetWidgetPropertyAction<Integer>(widgets.get(i).propY(),
-                                                                  dest - widgets.get(i).propHeight().getValue()));
+                                                                  max - widgets.get(i).propHeight().getValue()));
         }
     };
 

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/actions/ActionDescription.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/actions/ActionDescription.java
@@ -10,6 +10,7 @@ package org.csstudio.display.builder.editor.actions;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import org.csstudio.display.builder.editor.DisplayEditor;
 import org.csstudio.display.builder.editor.Messages;
@@ -190,9 +191,11 @@ public abstract class ActionDescription
             final UndoableActionManager undo = editor.getUndoableActionManager();
             if (widgets.size() < 2)
                 return;
-            final int dest = widgets.get(0).propX().getValue();
-            for (int i=1; i<widgets.size(); ++i)
-                undo.execute(new SetWidgetPropertyAction<Integer>(widgets.get(i).propX(), dest));
+            final int dest = widgets.stream()
+                                    .mapToInt(w -> w.propX().getValue())
+                                    .min()
+                                    .orElseThrow(NoSuchElementException::new);
+            widgets.stream().forEach(w -> undo.execute(new SetWidgetPropertyAction<Integer>(w.propX(), dest)));
         }
     };
 
@@ -225,10 +228,11 @@ public abstract class ActionDescription
             final UndoableActionManager undo = editor.getUndoableActionManager();
             if (widgets.size() < 2)
                 return;
-            final int dest = widgets.get(0).propX().getValue() + widgets.get(0).propWidth().getValue();
-            for (int i=1; i<widgets.size(); ++i)
-                undo.execute(new SetWidgetPropertyAction<Integer>(widgets.get(i).propX(),
-                                                                  dest - widgets.get(i).propWidth().getValue()));
+            final int dest = widgets.stream()
+                                    .mapToInt(w -> w.propX().getValue() + w.propWidth().getValue())
+                                    .max()
+                                    .orElseThrow(NoSuchElementException::new);
+            widgets.stream().forEach(w -> undo.execute(new SetWidgetPropertyAction<Integer>(w.propX(), dest - w.propWidth().getValue())));
         }
     };
 


### PR DESCRIPTION
- The selection, any kind of, made with any of the possible ways, defines a bounding box.
- TOP will align the top border of all widgets with the top border of the bounding box.
- BOTTOM will align the bottom border of all widgets with the bottom border of the bounding box;
- MIDDLE will align the center of all widgets with the center of the of the bounding box;
- Similarly for LEFT, RIGHT and CENTER.

<img width="391" alt="Screenshot 2019-03-15 at 14 11 49" src="https://user-images.githubusercontent.com/10833922/54526746-00cf4e80-4978-11e9-9512-ece058e1d3d7.png">
