### PR TITLE
Contextual menus restructured.

### DIFF
--- a/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/DisplayEditorPart.java
+++ b/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/DisplayEditorPart.java
@@ -68,6 +68,7 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.window.Window;
@@ -92,6 +93,7 @@ import org.eclipse.ui.views.properties.IPropertySheetPage;
 
 import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.input.Clipboard;
 
 /** RCP 'Editor' for the display builder
  *  @author Kay Kasemir
@@ -203,9 +205,37 @@ public class DisplayEditorPart extends EditorPart
         mm.setRemoveAllWhenShown(true);
         mm.addMenuListener(manager ->
         {
-            manager.add(execute);
 
             final List<Widget> selection = editor.getWidgetSelectionHandler().getSelection();
+            final int selectionSize = selection.size();
+
+            manager.add(new UndoAction(editor));
+            manager.add(new RedoAction(editor));
+            manager.add(new Separator());
+
+            final CutDeleteAction cutAction = new CutDeleteAction(editor, true);
+            final CopyAction copyAction = new CopyAction(editor);
+            final PasteAction pasteAction = new PasteAction(parent, editor);
+
+            cutAction.setEnabled(selectionSize >= 1);
+            copyAction.setEnabled(selectionSize >= 1);
+            pasteAction.setEnabled(Clipboard.getSystemClipboard().hasString());
+
+            manager.add(cutAction);
+            manager.add(copyAction);
+            manager.add(pasteAction);
+            manager.add(new Separator());
+
+
+
+
+
+
+            manager.add(execute);
+
+
+
+
             if (! selection.isEmpty())
             {
                 if (selection.size() >= 1)

--- a/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/EditEmbeddedDisplayAction.java
+++ b/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/EditEmbeddedDisplayAction.java
@@ -23,19 +23,23 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 @SuppressWarnings("nls")
 public class EditEmbeddedDisplayAction extends Action
 {
-    private String file;
+    private String file = null;
 
     public EditEmbeddedDisplayAction(final EmbeddedDisplayWidget widget)
     {
         super(Messages.EditEmbededDisplay,
               AbstractUIPlugin.imageDescriptorFromPlugin(ModelPlugin.ID, "icons/embedded.png"));
-        try
-        {
-            file = ModelResourceUtil.resolveResource(widget.getDisplayModel(), widget.propFile().getValue());
-        }
-        catch (Exception ex)
-        {
-            file = widget.propFile().getValue();
+        if ( widget != null ) {
+            try
+            {
+                file = ModelResourceUtil.resolveResource(widget.getDisplayModel(), widget.propFile().getValue());
+            }
+            catch (Exception ex)
+            {
+                file = widget.propFile().getValue();
+            }
+        } else {
+            setEnabled(false);
         }
     }
 

--- a/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/Messages.java
+++ b/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/Messages.java
@@ -19,7 +19,7 @@ public class Messages extends NLS
 
     // Keep in alphabetical order!
     public static String Copy;
-    public static String Delete;
+    public static String Cut;
     public static String DownloadPromptFMT;
     public static String DownloadTitle;
     public static String EditEmbededDisplay;
@@ -41,8 +41,11 @@ public class Messages extends NLS
     public static String NewDisplay_NotWriteable;
     public static String NewDisplay_Title;
     public static String OpenEditorPerspective;
+    public static String Paste;
+    public static String Redo;
     public static String ReplaceWith;
     public static String ReplaceWith_NoWidgets;
+    public static String Undo;
 
     static
     {

--- a/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/CopyAction.java
+++ b/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/CopyAction.java
@@ -8,6 +8,9 @@
 package org.csstudio.display.builder.editor.rcp.actions;
 
 import org.csstudio.display.builder.editor.DisplayEditor;
+import org.csstudio.display.builder.editor.rcp.Messages;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
 
 /** Action to copy to clipboard
@@ -18,6 +21,8 @@ public class CopyAction extends RetargetActionHandler
     public CopyAction(final DisplayEditor editor)
     {
         super(editor, ActionFactory.COPY.getCommandId());
+        setText(Messages.Copy);
+        setImageDescriptor(PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_TOOL_COPY));
     }
 
     @Override

--- a/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/CutDeleteAction.java
+++ b/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/CutDeleteAction.java
@@ -23,7 +23,7 @@ public class CutDeleteAction extends RetargetActionHandler
                       ? ActionFactory.CUT.getCommandId()
                       : ActionFactory.DELETE.getCommandId());
 
-        IWorkbenchAction action = ActionFactory.DELETE.create(PlatformUI.getWorkbench().getActiveWorkbenchWindow());
+        IWorkbenchAction action = ( cut_or_delete ? ActionFactory.CUT : ActionFactory.DELETE).create(PlatformUI.getWorkbench().getActiveWorkbenchWindow());
         setText(action.getText());
         setImageDescriptor(action.getImageDescriptor());
         action = null;

--- a/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/PasteAction.java
+++ b/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/PasteAction.java
@@ -10,9 +10,12 @@ package org.csstudio.display.builder.editor.rcp.actions;
 import java.util.Random;
 
 import org.csstudio.display.builder.editor.DisplayEditor;
+import org.csstudio.display.builder.editor.rcp.Messages;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
 
 /** Action to paste from clipboard
@@ -30,6 +33,8 @@ public class PasteAction extends RetargetActionHandler
     public PasteAction(final Control editor_control, final DisplayEditor editor)
     {
         super(editor, ActionFactory.PASTE.getCommandId());
+        setText(Messages.Paste);
+        setImageDescriptor(PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_TOOL_PASTE));
         this.editor_control = editor_control;
     }
 

--- a/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/RedoAction.java
+++ b/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/RedoAction.java
@@ -8,10 +8,13 @@
 package org.csstudio.display.builder.editor.rcp.actions;
 
 import org.csstudio.display.builder.editor.DisplayEditor;
+import org.csstudio.display.builder.editor.rcp.Messages;
 import org.csstudio.display.builder.editor.undo.GroupWidgetsAction;
 import org.csstudio.display.builder.editor.undo.RemoveWidgetsAction;
 import org.csstudio.display.builder.editor.undo.UnGroupWidgetsAction;
 import org.csstudio.display.builder.util.undo.UndoableAction;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
 
 /** Action to re-do last operation
@@ -22,6 +25,8 @@ public class RedoAction extends RetargetActionHandler
     public RedoAction(final DisplayEditor editor)
     {
         super(editor, ActionFactory.REDO.getCommandId());
+        setText(Messages.Redo);
+        setImageDescriptor(PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_TOOL_REDO));
         setEnabled(editor.getUndoableActionManager().canRedo());
     }
 

--- a/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/UndoAction.java
+++ b/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/actions/UndoAction.java
@@ -8,10 +8,13 @@
 package org.csstudio.display.builder.editor.rcp.actions;
 
 import org.csstudio.display.builder.editor.DisplayEditor;
+import org.csstudio.display.builder.editor.rcp.Messages;
 import org.csstudio.display.builder.editor.undo.AddWidgetAction;
 import org.csstudio.display.builder.editor.undo.GroupWidgetsAction;
 import org.csstudio.display.builder.editor.undo.UnGroupWidgetsAction;
 import org.csstudio.display.builder.util.undo.UndoableAction;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.ActionFactory;
 
 /** Action to un-do last operation
@@ -22,6 +25,8 @@ public class UndoAction extends RetargetActionHandler
     public UndoAction(final DisplayEditor editor)
     {
         super(editor, ActionFactory.UNDO.getCommandId());
+        setText(Messages.Undo);
+        setImageDescriptor(PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_TOOL_UNDO));
         setEnabled(editor.getUndoableActionManager().canUndo());
     }
 

--- a/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/messages.properties
+++ b/org.csstudio.display.builder.editor.rcp/src/org/csstudio/display/builder/editor/rcp/messages.properties
@@ -1,5 +1,5 @@
 Copy=Copy
-Delete=Delete
+Cut=Cut
 DownloadPromptFMT=Do you want to download\n\n{0}\n\ninto a local file so you can edit it?
 DownloadTitle=Download remote file
 EditEmbededDisplay=Edit Embedded Display
@@ -21,5 +21,8 @@ NewDisplay_MissingFileName=File name must be specified
 NewDisplay_NotWriteable=Project must be writable
 NewDisplay_Title=Display File
 OpenEditorPerspective=Open Editor Perspective
+Paste=Paste
+Redo=Redo
 ReplaceWith=Replace with
 ReplaceWith_NoWidgets=<No selected widgets>
+Undo=Undo

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tree/WidgetTree.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tree/WidgetTree.java
@@ -41,6 +41,8 @@ import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 import javafx.util.Callback;
 
 /** Tree view of widget hierarchy
@@ -172,6 +174,12 @@ public class WidgetTree
 
         bindSelections();
         tree_view.setOnKeyPressed(this::handleKeyPress);
+        tree_view.addEventFilter(MouseEvent.ANY, e -> {
+            if ( e.getButton() == MouseButton.SECONDARY ) {
+                //  Right-click should only open the context-menu and not select an element.
+                e.consume();
+            }
+        });
 
         return tree_view;
     }

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tree/WidgetTree.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/tree/WidgetTree.java
@@ -176,7 +176,9 @@ public class WidgetTree
         tree_view.setOnKeyPressed(this::handleKeyPress);
         tree_view.addEventFilter(MouseEvent.ANY, e -> {
             if ( e.getButton() == MouseButton.SECONDARY ) {
-                //  Right-click should only open the context-menu and not select an element.
+                //  Right-click should only open the context-menu and not select an element,
+                //  otherwise a selection occurs after the context-menu is open and the
+                //  menu items will be inconsistently enabled.
                 e.consume();
             }
         });


### PR DESCRIPTION
I've made the 2 contextual menu more similar to each other. Moreover no elements disappears/appears: instead their enabled status is changed.

<img width="672" alt="Screenshot 2019-03-21 at 18 14 33" src="https://user-images.githubusercontent.com/10833922/54771523-c2e75a00-4c05-11e9-929a-72eac217e729.png">

<img width="672" alt="Screenshot 2019-03-21 at 18 14 09" src="https://user-images.githubusercontent.com/10833922/54771432-8ddb0780-4c05-11e9-9188-62a5227831c8.png">
