### PR TITLE
Fixed LED of BoolButton initially drawn off-button if state-0 text is empty

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/BoolButtonRepresentation.java
@@ -95,6 +95,9 @@ public class BoolButtonRepresentation extends RegionBaseRepresentation<ButtonBas
         // Model has width/height, but JFX widget has min, pref, max size.
         // updateChanges() will set the 'pref' size, so make min use that as well.
         button.setMinSize(ButtonBase.USE_PREF_SIZE, ButtonBase.USE_PREF_SIZE);
+
+        toolkit.execute( ( ) -> Platform.runLater(button::requestLayout));
+
         return button;
     }
 


### PR DESCRIPTION
Fix for the following problem:

<img width="298" alt="Screenshot 2019-04-12 at 09 33 38" src="https://user-images.githubusercontent.com/10833922/56023951-4e3ca280-5d0f-11e9-8e2b-f7d1173e012a.png">
