### PR TITLE
CSSTUDIO-1026: Transparent Embedded Background

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/EmbeddedDisplayRepresentation.java
@@ -32,12 +32,12 @@ import javafx.scene.control.ScrollPane.ScrollBarPolicy;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.Border;
-import javafx.scene.layout.BorderStroke;
-import javafx.scene.layout.BorderStrokeStyle;
-import javafx.scene.layout.BorderWidths;
 import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.CycleMethod;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Stop;
 import javafx.scene.transform.Scale;
 
 /** Creates JavaFX item for model widget
@@ -55,7 +55,15 @@ import javafx.scene.transform.Scale;
 public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<ScrollPane, EmbeddedDisplayWidget>
 {
     private static final Background TRANSPARENT_BACKGROUND = new Background(new BackgroundFill(Color.TRANSPARENT, CornerRadii.EMPTY, Insets.EMPTY));
-    private static final Border EDIT_BORDER = new Border(new BorderStroke(new Color(0.45, 0.44, 0.43, 0.7), BorderStrokeStyle.DOTTED, CornerRadii.EMPTY, BorderWidths.DEFAULT));
+    private static final Background EDIT_TRANSPARENT_BACKGROUND = new Background(new BackgroundFill(
+        new LinearGradient(
+            0, 0, 10, 10, false, CycleMethod.REPEAT,
+            new Stop(0.0, new Color(0.53, 0.52, 0.51, 0.15)),
+            new Stop(0.5, new Color(0.53, 0.52, 0.51, 0.15)),
+            new Stop(0.5, Color.TRANSPARENT),
+            new Stop(1.0, Color.TRANSPARENT)
+        ), CornerRadii.EMPTY, Insets.EMPTY
+    ));
 
     private final DirtyFlag dirty_sizes = new DirtyFlag();
     private final DirtyFlag dirty_background = new DirtyFlag();
@@ -72,7 +80,6 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
      */
     private volatile Pane inner;
     private volatile Background inner_background = Background.EMPTY;
-    private volatile Border inner_border = Border.EMPTY;
 
     private Scale zoom;
     private ScrollPane scroll;
@@ -292,7 +299,7 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
 
             // Reinstall the frame in edit mode. Scroll is unusable, so make it with inner
             if (toolkit.isEditMode())
-                inner_border = EDIT_BORDER;
+                inner_background = EDIT_TRANSPARENT_BACKGROUND;
         }
         else
         {
@@ -300,16 +307,6 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
                 inner_background = Background.EMPTY;
             else
                 inner_background = new Background(new BackgroundFill(JFXUtil.convert(content_model.propBackgroundColor().getValue()), CornerRadii.EMPTY, Insets.EMPTY));
-
-            // TODO Haven't found perfect way to set the 'background' color
-            // of the embedded content.
-            // Setting the 'inner' background will sometimes leave a gray section in the right and or bottom edge
-            // of the embedded content if the container is (much) larger than the content
-            // The scroll pane background can only be set via style,
-            // and then shines through on the outside of the scrollbars
-            // scroll.setStyle("-fx-control-inner-background: " + JFXUtil.webRGB(content_model.propBackgroundColor().getValue()) +
-            //                  "; -fx-background: " + JFXUtil.webRGB(content_model.propBackgroundColor().getValue()));
-            inner_border = Border.EMPTY;
         }
 
         dirty_background.mark();
@@ -355,7 +352,15 @@ public class EmbeddedDisplayRepresentation extends RegionBaseRepresentation<Scro
         if (dirty_background.checkAndClear())
         {
             inner.setBackground(inner_background);
-            inner.setBorder(inner_border);
+            // TODO Haven't found perfect way to set the 'background' color
+            // of the embedded content.
+            // Setting the 'inner' background will sometimes leave a gray section in the right and or bottom edge
+            // of the embedded content if the container is (much) larger than the content
+            // The scroll pane background can only be set via style,
+            // and then shines through on the outside of the scrollbars
+            // scroll.setStyle("-fx-control-inner-background: " + JFXUtil.webRGB(content_model.propBackgroundColor().getValue()) +
+            //                  "; -fx-background: " + JFXUtil.webRGB(content_model.propBackgroundColor().getValue()));
+            inner.setBorder(Border.EMPTY);
         }
     }
 


### PR DESCRIPTION
In Edit mode, transparent Embedded displays with "No Resize" setting show unnecessary scrollbars when sized to the same size of the embedded content and the embedded OPI has its own content "touching" the boundaries.

This happens because in Edit mode a 1 pixel semi-transparent grey border is displayed inside the Embedded Display to identify the widget.

This PR replaces the this border with a transparent pattern background:

<img width="349" alt="Screenshot 2019-05-10 at 13 47 13" src="https://user-images.githubusercontent.com/10833922/57525935-5eef3100-732c-11e9-93be-d088cec08670.png">
