### PR TITLE
CSSTUDIO-949: Removing dependency version for ControlsFX

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/META-INF/MANIFEST.MF
+++ b/org.csstudio.display.builder.representation.javafx/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.osgi,
  se.europeanspallationsource.javafx.control.medusa,
  se.europeanspallationsource.javafx.control.thumbwheel,
  se.europeanspallationsource.xaos,
- org.controlsfx;bundle-version="8.40.14"
+ org.controlsfx
 Export-Package: org.csstudio.display.builder.representation.javafx,
  org.csstudio.display.builder.representation.javafx.sandbox,
  org.csstudio.display.builder.representation.javafx.widgets


### PR DESCRIPTION
Related to [maven-osgi-bundles#84](https://github.com/ControlSystemStudio/maven-osgi-bundles/pull/84).

This PR will remove to needs to update this version number each time `maven-osgi-bundles` is updated.