### PR TITLE
Suppressed IllegalArgumentException when parent is null.

### DIFF
--- a/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
+++ b/org.csstudio.display.builder.representation.javafx/src/org/csstudio/display/builder/representation/javafx/widgets/JFXBaseRepresentation.java
@@ -189,7 +189,9 @@ abstract public class JFXBaseRepresentation<JFX extends Node, MW extends Widget>
     {
         unregisterListeners();
         Objects.requireNonNull(jfx_node);
-        JFXRepresentation.getChildren(jfx_node.getParent()).remove(jfx_node);
+        Parent parent = jfx_node.getParent();
+        if (parent != null)
+            JFXRepresentation.getChildren(jfx_node.getParent()).remove(jfx_node);
         jfx_node = null;
     }
 


### PR DESCRIPTION
Sometimes when an OPI is closed the following shows up in the console (but not in the logs):

```
2019-06-12 17:27:57.820 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
2019-06-12 17:30:01.302 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
2019-06-12 18:37:44.649 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
2019-06-12 18:41:25.397 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
2019-06-12 18:42:18.839 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
2019-06-12 18:42:42.141 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
2019-06-12 18:43:49.658 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
2019-06-12 18:44:33.347 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
2019-06-12 18:45:48.635 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
2019-06-12 18:48:28.622 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
2019-06-12 18:49:55.711 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
WARNING: You are binding against the deprecated org.eclipse.fx.javafx - please remove all javafx imports
Exception in thread "JavaFX Application Thread" java.lang.IllegalArgumentException: Expecting Group or Pane, got null
	at org.csstudio.display.builder.representation.javafx.JFXRepresentation.getChildren(JFXRepresentation.java:658)
	at org.csstudio.display.builder.representation.javafx.widgets.JFXBaseRepresentation.dispose(JFXBaseRepresentation.java:192)
	at org.csstudio.display.builder.representation.WidgetRepresentation.destroy(WidgetRepresentation.java:85)
	at org.csstudio.display.builder.representation.ToolkitRepresentation.disposeWidget(ToolkitRepresentation.java:361)
	at org.csstudio.display.builder.representation.ToolkitRepresentation.disposeChildren(ToolkitRepresentation.java:336)
	at org.csstudio.display.builder.representation.ToolkitRepresentation.disposeRepresentation(ToolkitRepresentation.java:320)
	at org.csstudio.display.builder.representation.javafx.JFXRepresentation.disposeRepresentation(JFXRepresentation.java:795)
	at org.csstudio.display.builder.representation.javafx.JFXRepresentation.disposeRepresentation(JFXRepresentation.java:1)
	at org.csstudio.display.builder.runtime.ActionUtil.lambda$14(ActionUtil.java:221)
	at com.sun.javafx.application.PlatformImpl.lambda$null$172(PlatformImpl.java:295)
	at java.security.AccessController.doPrivileged(Native Method)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$173(PlatformImpl.java:294)
	at org.eclipse.swt.internal.gtk.OS._g_main_context_iteration(Native Method)
	at org.eclipse.swt.internal.gtk.OS.g_main_context_iteration(OS.java:2116)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:4181)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1150)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1039)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:680)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:594)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:148)
	at org.csstudio.utility.product.Workbench.runWorkbench(Workbench.java:99)
	at org.csstudio.startup.application.Application.startApplication(Application.java:265)
	at org.csstudio.startup.application.Application.start(Application.java:119)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:388)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:243)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:653)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:590)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1499)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1472)
2019-06-12 18:51:40.553 WARNING [Thread 1] org.csstudio.display.builder.representation.javafx.JFXRepresentation (shutdown) - Display representation still contains items on shutdown
```

This PR suppresses the `java.lang.IllegalArgumentException` when parent is `null`.