### PR TITLE
TextField properties highlighted.

### DIFF
--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -335,7 +335,7 @@ public class PropertyPanelSection extends GridPane
                     if (combo.isVisible())
                     {
                         combo.requestFocus();
-                        combo.getEditor().selectAll();
+//                        combo.getEditor().selectAll();
                     }
                     else if (check.isVisible())
                         check.requestFocus();

--- a/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
+++ b/org.csstudio.display.builder.editor/src/org/csstudio/display/builder/editor/properties/PropertyPanelSection.java
@@ -335,7 +335,6 @@ public class PropertyPanelSection extends GridPane
                     if (combo.isVisible())
                     {
                         combo.requestFocus();
-//                        combo.getEditor().selectAll();
                     }
                     else if (check.isVisible())
                         check.requestFocus();

--- a/org.csstudio.javafx/src/org/csstudio/javafx/InputUtils.java
+++ b/org.csstudio.javafx/src/org/csstudio/javafx/InputUtils.java
@@ -8,6 +8,7 @@
  */
 package org.csstudio.javafx;
 
+import javafx.application.Platform;
 import javafx.event.EventHandler;
 import javafx.event.EventTarget;
 import javafx.event.EventType;
@@ -35,44 +36,51 @@ import javafx.scene.input.KeyEvent;
  */
 public class InputUtils {
 
+    private static final String FOCUSED_EDITOR_STYLE = "-fx-control-inner-background: #FFFF77F0;";
+    private static final String MODIFIED_EDITOR_STYLE = "-fx-control-inner-background: #FFCCBBF0;";
+
     private InputUtils ( ) {
     }
 
     public static <T extends Node> T wrap ( T component ) {
 
-        component.addEventFilter(KeyEvent.ANY, new EnterHandler());
+        component.addEventFilter(KeyEvent.ANY, new EnterHandler<>(component));
         component.focusedProperty().addListener(( ob, o, n ) -> {
-            component.setStyle(component.isFocused() ? "-fx-control-inner-background: #FFFF77F0;" : null);
+
+            component.setStyle(component.isFocused() ? FOCUSED_EDITOR_STYLE : null);
+
+            final TextField editor;
+
+            if ( component instanceof ComboBox<?> ) {
+                editor = ((ComboBox<?>) component).getEditor();
+            } else if ( component instanceof TextField ) {
+                editor = (TextField) component;
+            } else {
+                editor = null;
+            }
+
+            if ( editor != null ) {
+                //  This trick will allow TextFiel in a ComboBox to be
+                //  selected when focus is obtained via TAB or click.
+                new Thread(() -> Platform.runLater(editor::selectAll)).start();
+            }
+
         });
-
-        final TextField editor;
-
-        if ( component instanceof ComboBox<?> ) {
-
-            editor = ((ComboBox<?>) component).getEditor();
-
-            ((ComboBox<?>) component).focusedProperty().addListener(( ob, o, n ) ->
-                editor.selectAll());
-
-        } else if ( component instanceof TextField ) {
-            editor = (TextField) component;
-        } else {
-            editor = null;
-        }
-
-        if ( editor != null ) {
-            editor.setOnMouseReleased(e -> editor.selectAll());
-        }
 
         return component;
 
     }
 
-    private static class EnterHandler implements EventHandler<KeyEvent> {
+    private static class EnterHandler<T extends Node> implements EventHandler<KeyEvent> {
 
         private KeyCode pressedCode = null;
         private KeyCode typedCode = null;
         private String character = null;
+        private T component;
+
+        public EnterHandler ( T component ) {
+            this.component = component;
+        }
 
         @Override
         public void handle ( KeyEvent event ) {
@@ -80,8 +88,17 @@ public class InputUtils {
             EventType<KeyEvent> eventType = event.getEventType();
 
             if ( eventType == KeyEvent.KEY_PRESSED ) {
+
                 pressedCode = event.getCode();
+
+                if ( pressedCode == KeyCode.ENTER || pressedCode == KeyCode.ESCAPE) {
+                    component.setStyle(component.isFocused() ? FOCUSED_EDITOR_STYLE : null);
+                } else if ( !( pressedCode.isFunctionKey() || pressedCode.isMediaKey() || pressedCode.isModifierKey() || pressedCode.isNavigationKey() ) ) {
+                    component.setStyle(component.isFocused() ? MODIFIED_EDITOR_STYLE : null);
+                }
+
                 return;
+
             } else if ( eventType == KeyEvent.KEY_TYPED ) {
                 typedCode = event.getCode();
                 character = event.getCharacter();

--- a/org.csstudio.javafx/src/org/csstudio/javafx/InputUtils.java
+++ b/org.csstudio.javafx/src/org/csstudio/javafx/InputUtils.java
@@ -12,6 +12,8 @@ import javafx.event.EventHandler;
 import javafx.event.EventTarget;
 import javafx.event.EventType;
 import javafx.scene.Node;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 
@@ -39,6 +41,28 @@ public class InputUtils {
     public static <T extends Node> T wrap ( T component ) {
 
         component.addEventFilter(KeyEvent.ANY, new EnterHandler());
+        component.focusedProperty().addListener(( ob, o, n ) -> {
+            component.setStyle(component.isFocused() ? "-fx-control-inner-background: #FFFF77F0;" : null);
+        });
+
+        final TextField editor;
+
+        if ( component instanceof ComboBox<?> ) {
+
+            editor = ((ComboBox<?>) component).getEditor();
+
+            ((ComboBox<?>) component).focusedProperty().addListener(( ob, o, n ) ->
+                editor.selectAll());
+
+        } else if ( component instanceof TextField ) {
+            editor = (TextField) component;
+        } else {
+            editor = null;
+        }
+
+        if ( editor != null ) {
+            editor.setOnMouseReleased(e -> editor.selectAll());
+        }
 
         return component;
 


### PR DESCRIPTION
I have complains about TextField-based properties
- not being easily visible the one where the caret is inside,
- not being easily visible if the ENTER key was pressed or not,
- not being easily usable because when click inside the content is not selected, 
- TAB navigation automatically select the content but not for editable combo boxes.

This PR addresses the problems in the following way:
- focused (and not yet modified) TextFields have a yellowish background and the content is initially selected;
- as soon as a new content is typed, the background change to reddish until ENTER is pressed, where is switched back to the yellowish one.

![Screenshot 2019-06-27 at 14 40 41](https://user-images.githubusercontent.com/10833922/60267598-e0a21a80-98ea-11e9-9fe1-158a962e4075.png)
![Screenshot 2019-06-27 at 14 41 01](https://user-images.githubusercontent.com/10833922/60267604-e39d0b00-98ea-11e9-9466-d2ca91487369.png)


